### PR TITLE
Fix: Fix asset upload error

### DIFF
--- a/YAIIU/YAIIU/Services/UploadManager.swift
+++ b/YAIIU/YAIIU/Services/UploadManager.swift
@@ -465,6 +465,7 @@ class UploadManager: ObservableObject {
                 return result
             }
         } catch {
+            logDebug("Failed to get timezone from location, falling back to current. Error: \(error.localizedDescription)", category: .upload)
             return TimeZone.current
         }
     }


### PR DESCRIPTION
### **User description**
## Description

Don't use the shared CLGeocoder to prevent upload error


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced shared `CLGeocoder` with per-request instances.

- Added a 3-second timeout for timezone lookups.

- Falls back to device timezone on failure or timeout.

- Simplified timezone-related error handling.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["getTimezone()"] --> B{"withThrowingTaskGroup"};
  B -- "Starts" --> C["Geocoding Task (new CLGeocoder)"];
  B -- "Starts" --> D["Timeout Task (3s)"];
  C -- "Success (< 3s)" --> E["Return Geocoded Timezone"];
  D -- "Fires first" --> F["Fallback to TimeZone.current"];
  C -- "Fails" --> F;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UploadManager.swift</strong><dd><code>Refactor timezone geocoding to prevent upload hangs and add a timeout</code></dd></summary>
<hr>

YAIIU/YAIIU/Services/UploadManager.swift

<ul><li>Replaced the shared <code>CLGeocoder</code> instance with a new one created for <br>each timezone lookup to avoid concurrency issues.<br> <li> Implemented a 3-second timeout for the geocoding operation using a <br><code>TaskGroup</code>, falling back to the current timezone.<br> <li> Simplified the <code>TimezoneGeocodingError</code> enum to <code>timeout</code> and <code>failed</code>.<br> <li> Improved logging for when timezone geocoding fails.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/10/files#diff-1d1c676963b6bd0fa269f288d91733f1f199371693ef8c4975fa5c328bd0e9b4">+27/-65</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

