### PR TITLE
fix: Show correct date in navigation bar

### DIFF
--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -316,8 +316,6 @@ struct PhotoGridView: View {
             .frame(width: geometry.size.width, height: geometry.size.height)
             .onDisappear {
                 visibleDisplayIndices.removeAll()
-                currentVisibleDate = ""
-                firstRowTopOffset = 0
             }
         }
     }
@@ -347,7 +345,11 @@ struct PhotoGridView: View {
                     gridItemView(assetIndex: actualIndex, displayIndex: displayIndex)
                         .background(
                             // Track first row position using GeometryReader
-                            displayIndex == 0 ? AnyView(firstRowTracker) : AnyView(EmptyView())
+                            Group {
+                                if displayIndex == 0 {
+                                    firstRowTracker
+                                }
+                            }
                         )
                 }
             }


### PR DESCRIPTION
### **User description**
## Description

This PR fixes error date in the navigation bar


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replaced item visibility tracking with scroll offset detection.

- Uses `PreferenceKey` to determine navigation title content.

- Removed unnecessary state resets on view disappearance.

- Resets scroll state correctly on pull-to-refresh.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Item Visibility Tracking"] -- "Replaced by" --> B["Scroll Offset Tracking"];
  B --> C{"Is first row scrolled up?"};
  C -- Yes --> D["Display Date in Nav Title"];
  C -- No --> E["Display 'Photo Library' in Nav Title"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Refactor navigation title logic to use scroll offset tracking</code></dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>Replaced item visibility tracking with a more robust scroll offset <br>tracking using <code>PreferenceKey</code> to determine when to show the date in the <br>navigation title.<br> <li> Introduced <code>FirstRowOffsetKey</code> and a <code>GeometryReader</code> to monitor the first <br>row's position.<br> <li> Removed the <code>isFirstItemVisible</code> state and simplified the logic for the <br><code>navigationTitle</code>.<br> <li> Removed unnecessary state resets in <code>.onDisappear</code> and added proper <br>state reset on pull-to-refresh.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/17/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+51/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

