### PR TITLE
Fix: Update bundle property to be nonisolated in LanguageManager

### DIFF
--- a/YAIIU/YAIIU/Utilities/Localization.swift
+++ b/YAIIU/YAIIU/Utilities/Localization.swift
@@ -62,7 +62,16 @@ final class LanguageManager: ObservableObject {
         }
     }
     
-    nonisolated(unsafe) private(set) var bundle: Bundle = .main
+    nonisolated(unsafe) private let bundleLock = NSLock()
+    nonisolated(unsafe) private var _bundle: Bundle = .main
+    nonisolated private(set) var bundle: Bundle {
+        get {
+            bundleLock.withLock { _bundle }
+        }
+        set {
+            bundleLock.withLock { _bundle = newValue }
+        }
+    }
     
     private init() {
         if let stored = UserDefaults.standard.string(forKey: Self.languageKey),


### PR DESCRIPTION
### **User description**
## Description

Fix build error


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implements thread-safe access for the `bundle` property.

- Uses `NSLock` to prevent potential data race conditions.

- Refactors `bundle` into a computed property with a backing store.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Unsafe Access"] -- "Refactor" --> B["Thread-Safe Access"];
    subgraph B
        B1["NSLock"]
        B2["Computed Property (bundle)"]
        B3["Backing Property (_bundle)"]
        B1 --> B2;
    end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Localization.swift</strong><dd><code>Implement thread-safe access for the `bundle` property</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Utilities/Localization.swift

<ul><li>Replaces the <code>bundle</code> stored property with a computed property.<br> <li> Introduces an <code>NSLock</code> (<code>bundleLock</code>) to synchronize access to a private <br>backing property (<code>_bundle</code>).<br> <li> Makes the <code>bundle</code> property thread-safe by using the lock in its getter <br>and setter.<br> <li> Marks the lock and backing property as <code>nonisolated(unsafe)</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/20/files#diff-d7ed95e2bea1a14e72c00ae8bc5798524f74e98778cfb067effb220b7b7579ce">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

