### PR TITLE
fix: FIx not hashing when open app

### DIFF
--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -628,9 +628,6 @@ struct PhotoGridView: View {
         if currentFilter == .notUploaded {
             refreshFilterCache()
         }
-        
-        // Start background processing unconditionally after refresh
-        startBackgroundProcessing()
     }
     
     
@@ -747,13 +744,11 @@ struct PhotoGridView: View {
             logInfo("Auto sync completed: \(syncResult.syncType), total: \(syncResult.totalAssets), upserted: \(syncResult.upsertedCount), deleted: \(syncResult.deletedCount)", category: .sync)
             
             hashManager.refreshStatusCache()
-            startBackgroundProcessing()
             
         case .failure(let error):
             logError("Auto sync failed: \(error.localizedDescription)", category: .sync)
-            // Start background processing even if sync fails (for local hashing)
-            startBackgroundProcessing()
         }
+        startBackgroundProcessing()
     }
 }
 


### PR DESCRIPTION
### **User description**
## Description

Fixes the app not hashing assets when open app.


___

### **PR Type**
Bug fix


___

### **Description**
- Ensure background processing starts after sync attempts.

- Initiate processing even if server sync is skipped.

- Remove redundant background processing calls on refresh.

- Simplify UI update logic within the refresh function.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["refreshPhotosAsync()"] --> B["performAutoSync()"]
  B --> C{"Server Configured?"}
  C -- "No" --> D["startBackgroundProcessing()"]
  C -- "Yes" --> E["Sync Attempt"]
  E --> F["handleSyncResult()"]
  F --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Refactor background processing trigger logic for reliability</code></dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>Ensures <code>startBackgroundProcessing()</code> is called after every sync attempt <br>by adding it to <code>handleSyncResult</code>.<br> <li> Triggers background processing even when auto-sync is skipped due to <br>missing server configuration.<br> <li> Removes a now-redundant call to <code>startBackgroundProcessing()</code> from <br><code>refreshPhotosAsync</code>.<br> <li> Simplifies <code>refreshPhotosAsync</code> by removing a deferred <code>Task</code> used for UI <br>updates.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/21/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+13/-20</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

