### PR TITLE
feat: Keep screen on when uploading

### DIFF
--- a/YAIIU/YAIIU/Services/UploadManager.swift
+++ b/YAIIU/YAIIU/Services/UploadManager.swift
@@ -454,8 +454,12 @@ class UploadManager: ObservableObject {
     /// Prevent the screen from dimming while uploads are active.
     /// The system automatically re-enables the idle timer when the app terminates.
     private func setIdleTimerDisabled(_ disabled: Bool) {
-        DispatchQueue.main.async {
+        if Thread.isMainThread {
             UIApplication.shared.isIdleTimerDisabled = disabled
+        } else {
+            DispatchQueue.main.async {
+                UIApplication.shared.isIdleTimerDisabled = disabled
+            }
         }
     }
     


### PR DESCRIPTION
### **User description**
## Description

This PR adds the feature to keep the screen on when uploading assets.


___

### **PR Type**
Enhancement


___

### **Description**
- Keeps the screen on during the asset upload process.

- Disables the system idle timer when an upload starts.

- Re-enables the timer when an upload is paused, completed, or cleared.

- Ensures thread-safe access to the idle timer property.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Upload Process"] -- "Starts" --> B["Screen Kept On (Idle Timer Disabled)"];
  B -- "Pauses, Finishes, or is Cleared" --> C["Screen Can Dim (Idle Timer Enabled)"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>UploadManager.swift</strong><dd><code>Implement logic to keep the screen active during uploads</code>&nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/UploadManager.swift

<ul><li>Adds a new private function <code>setIdleTimerDisabled</code> to manage the <br>application's idle timer.<br> <li> Disables the idle timer in <code>startUpload</code> to prevent the screen from <br>locking.<br> <li> Re-enables the idle timer when the upload process stops (e.g., on <br>pause, completion, or clearing).<br> <li> Ensures the <code>isIdleTimerDisabled</code> property is safely modified on the <br>main thread.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/24/files#diff-1d1c676963b6bd0fa269f288d91733f1f199371693ef8c4975fa5c328bd0e9b4">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

