### PR TITLE
fix: Use correct project version

### DIFF
--- a/.github/workflows/deploy-appstore.yml
+++ b/.github/workflows/deploy-appstore.yml
@@ -85,7 +85,7 @@ jobs:
           # Generate JWT token for App Store Connect API
           now = int(time.time())
           token = jwt.encode(
-              {"iss": issuer_id, "iat": now, "exp": now + 1200, "aud": "appstoreconnect-v1"},
+              {"iss": issuer_id, "iat": now, "exp": now + 300, "aud": "appstoreconnect-v1"},
               private_key,
               algorithm="ES256",
               headers={"kid": key_id}
@@ -99,8 +99,8 @@ jobs:
               app_data = json.loads(resp.read())
 
           if not app_data.get("data"):
-              print("1", end="")
-              sys.exit(0)
+              print(f"Error: App with bundle ID '{bundle_id}' not found.", file=sys.stderr)
+              sys.exit(1)
 
           app_id = app_data["data"][0]["id"]
 


### PR DESCRIPTION
### **User description**
## Description

This PR fixes CI error by using correct project version


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Dynamically fetch the next build number from App Store Connect.

- Add a new workflow step with a Python script for API communication.

- Securely authenticate with the App Store Connect API using a JWT.

- Replace `github.run_number` with the dynamic build number in the build process.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CI Workflow"] --> B{"Get next build number"};
  B -- "Auth with JWT" --> C["App Store Connect API"];
  C -- "Returns latest build info" --> B;
  B -- "Calculates next number" --> D["Set Xcode Project Version"];
  D --> E["Archive App Step"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy-appstore.yml</strong><dd><code>Implement dynamic build number fetching from App Store Connect API</code></dd></summary>
<hr>

.github/workflows/deploy-appstore.yml

<ul><li>Adds a new step, <code>Get next build number from App Store Connect</code>, to the <br>deployment workflow.<br> <li> Implements an inline Python script to communicate with the App Store <br>Connect API, using JWT for authentication.<br> <li> The script fetches the highest existing build number and calculates <br>the next one.<br> <li> Replaces the use of <code>${{ github.run_number }}</code> with the new dynamic <br>build number (<code>${{ steps.build_number.outputs.BUILD_NUMBER }}</code>) for <br><code>CURRENT_PROJECT_VERSION</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/27/files#diff-336d936129f1499068832417d2247b22e7e610d242f88fba09f4846c30af0c46">+80/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

