### PR TITLE
fix: FIx app not using active server URL for some actions

### DIFF
--- a/YAIIU/YAIIU/Services/FavoriteSyncService.swift
+++ b/YAIIU/YAIIU/Services/FavoriteSyncService.swift
@@ -111,7 +111,7 @@ class FavoriteSyncService {
         try await ImmichAPIService.shared.updateAssetsFavorite(
             assetIds: assetIds,
             isFavorite: isFavorite,
-            serverURL: settingsManager.serverURL,
+            serverURL: settingsManager.activeServerURL,
             apiKey: settingsManager.apiKey
         )
     }

--- a/YAIIU/YAIIU/Services/UploadManager.swift
+++ b/YAIIU/YAIIU/Services/UploadManager.swift
@@ -224,7 +224,7 @@ class UploadManager: ObservableObject {
     
     private func processUploadQueueParallel() async {
         let settingsManager = SettingsManager()
-        let serverURL = settingsManager.serverURL
+        let serverURL = settingsManager.activeServerURL
         let apiKey = settingsManager.apiKey
         
         guard !serverURL.isEmpty && !apiKey.isEmpty else {

--- a/YAIIU/YAIIU/Views/InitialSetupView.swift
+++ b/YAIIU/YAIIU/Views/InitialSetupView.swift
@@ -186,7 +186,7 @@ struct InitialSetupView: View {
         logInfo("Starting initial setup sync", category: .sync)
         
         ServerAssetSyncService.shared.syncServerAssets(
-            serverURL: settingsManager.serverURL,
+            serverURL: settingsManager.activeServerURL,
             apiKey: settingsManager.apiKey,
             forceFullSync: true,
             progressHandler: { [self] progress in

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -997,7 +997,7 @@ struct PhotoGridView: View {
     // MARK: - Auto Sync
     
     private func performAutoSync() {
-        let serverURL = settingsManager.serverURL
+        let serverURL = settingsManager.activeServerURL
         let apiKey = settingsManager.apiKey
         
         if !hashManager.isProcessing {


### PR DESCRIPTION
### **User description**
## Description

This PR fixes some actions not using active server URL


___

### **PR Type**
Bug fix


___

### **Description**
- Ensures various actions use the active server URL.

- Fixes incorrect server URL usage for:
  - Favorite syncing
  - Asset uploads
  - Initial setup sync
  - Auto-sync in the photo grid


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph "Affected Components"
      A["FavoriteSyncService"]
      B["UploadManager"]
      C["InitialSetupView"]
      D["PhotoGridView"]
  end
  
  Settings["settingsManager"]
  
  Settings -- "activeServerURL" --> A
  Settings -- "activeServerURL" --> B
  Settings -- "activeServerURL" --> C
  Settings -- "activeServerURL" --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FavoriteSyncService.swift</strong><dd><code>Use active server URL for updating favorite status</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/FavoriteSyncService.swift

<ul><li>The <code>updateServerFavorites</code> function now uses <br><code>settingsManager.activeServerURL</code> to ensure favorite status updates are <br>sent to the correct server.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/34/files#diff-969983f1d39c5d337b810e7d0e423f5468c1a64339c0dfdaf5240f7b3c59b672">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>UploadManager.swift</strong><dd><code>Use active server URL for parallel upload processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/UploadManager.swift

<ul><li>The <code>processUploadQueueParallel</code> function now retrieves the <br><code>activeServerURL</code> to correctly process the upload queue.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/34/files#diff-1d1c676963b6bd0fa269f288d91733f1f199371693ef8c4975fa5c328bd0e9b4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>InitialSetupView.swift</strong><dd><code>Use active server URL for initial server asset sync</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Views/InitialSetupView.swift

<ul><li>The initial asset sync process now uses <code>activeServerURL</code> when calling <br><code>syncServerAssets</code>.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/34/files#diff-cd43691d3bb2ec80138893e33f9c532b6818ec3399f3a8b8d8d3917a2535991f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Use active server URL for auto-sync in photo grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>The <code>performAutoSync</code> function has been updated to use <code>activeServerURL</code> <br>for auto-sync operations.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/34/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

