### PR TITLE
Fix: Extend Timeout

### DIFF
--- a/YAIIU/YAIIU/Services/ImmichAPIService.swift
+++ b/YAIIU/YAIIU/Services/ImmichAPIService.swift
@@ -115,7 +115,7 @@ class ImmichAPIService: NSObject {
         let cloudIdInfo = iCloudId != nil ? ", iCloudId: \(iCloudId!.prefix(20))..." : ""
         logInfo("Starting streaming upload: \(filename) (\(String(format: "%.2f", fileSizeMB)) MB)\(cloudIdInfo)", category: .api)
 
-        let streamBufferSize = 4 * 1024 * 1024
+        let streamBufferSize = 16 * 1024 * 1024
         var readStream: InputStream?
         var writeStream: OutputStream?
         Stream.getBoundStreams(withBufferSize: streamBufferSize, inputStream: &readStream, outputStream: &writeStream)


### PR DESCRIPTION
### **User description**
## Description

This PR extends timeout to prevent errors when uploading large videos. Also, we scale up the steam buffer size for bettter upload experience.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Increases upload timeouts to support large files.

- Enlarges the stream buffer size for better performance.

- Prevents errors when uploading large videos.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    A["Old Config (Small Timeout/Buffer)"] -- "Leads to" --> B["Upload Errors for Large Files"];
    C["New Config (Large Timeout/Buffer)"] -- "Prevents" --> B;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImmichAPIService.swift</strong><dd><code>Increase upload timeouts and stream buffer size</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/ImmichAPIService.swift

<ul><li>Increases <code>timeoutIntervalForRequest</code> from 5 minutes to 30 minutes.<br> <li> Increases <code>timeoutIntervalForResource</code> from 1 hour to 2 hours.<br> <li> Quadruples the <code>streamBufferSize</code> from 4MB to 16MB to improve upload <br>performance.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/37/files#diff-154c284418e40449c5da49bf0d1b57ced3aabe1e60406d108ddf15d0f7662dce">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

