### PR TITLE
fix: Use mobile-app key instead of yaiiu-app key for old Immich compatibility

### DIFF
--- a/YAIIU/YAIIU/Services/ImmichAPIService.swift
+++ b/YAIIU/YAIIU/Services/ImmichAPIService.swift
@@ -41,7 +41,7 @@ struct RemoteAssetMetadataItem: Encodable {
     let key: String
     let value: MobileAppMetadata
     
-    static let mobileAppKey = "yaiiu-app"
+    static let mobileAppKey = "mobile-app"
 }
 
 class ImmichAPIService: NSObject {

--- a/immich-proxy/handlers/background_upload.go
+++ b/immich-proxy/handlers/background_upload.go
@@ -274,7 +274,7 @@ func createMultipartRequest(metadata BackgroundUploadRequest, photoData []byte) 
 	// Include mobile-app metadata with iCloudId if available
 	if metadata.ICloudId != "" {
 		metadataItem := RemoteAssetMetadataItem{
-			Key: "yaiiu-app",
+			Key: "mobile-app",
 			Value: MobileAppMetadata{
 				ICloudId:  metadata.ICloudId,
 				CreatedAt: metadata.FileCreatedAt,


### PR DESCRIPTION
### **User description**
## Description

This PR is to solve https://github.com/FawenYo/YAIIU/issues/41 by using `mobile-app` key instead of `yaiiu-app` key to fix compatibility issues with the old Immich server.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes `400 Bad Request` errors during uploads.

- Aligns metadata key with Immich server requirements.

- Updates key from `yaiiu-app` to `mobile-app`.

- Applies fix to both the iOS app and Go proxy.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph "Before"
        A["Client (iOS/Go)"] -- "key: 'yaiiu-app'" --> B{Immich API}
        B -- "400 Bad Request" --> A
    end
    subgraph "After"
        C["Client (iOS/Go)"] -- "key: 'mobile-app'" --> D{Immich API}
        D -- "200 OK" --> C
    end
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ImmichAPIService.swift</strong><dd><code>Update metadata key for Immich compatibility in iOS app</code>&nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/ImmichAPIService.swift

<ul><li>Updated the static <code>mobileAppKey</code> from <code>yaiiu-app</code> to <code>mobile-app</code>.<br> <li> This change ensures the iOS application sends the correct metadata key <br>required by the Immich server.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/42/files#diff-154c284418e40449c5da49bf0d1b57ced3aabe1e60406d108ddf15d0f7662dce">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>background_upload.go</strong><dd><code>Update metadata key for Immich compatibility in Go proxy</code>&nbsp; </dd></summary>
<hr>

immich-proxy/handlers/background_upload.go

<ul><li>Changed the hardcoded metadata <code>Key</code> from <code>yaiiu-app</code> to <code>mobile-app</code> within <br>the <code>createMultipartRequest</code> function.<br> <li> This aligns the Go proxy's upload requests with the Immich server's <br>expected metadata format.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/42/files#diff-6a2033e9b0a99c77a21751e95c44ea6650fb4ca4ea6036fcfc3490729b6f652f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

