### PR TITLE
Fix: Prevent video assets saved as upload.jpg

### DIFF
--- a/YAIIU/BackgroundUploadExtension/BackgroundUploadExtension.swift
+++ b/YAIIU/BackgroundUploadExtension/BackgroundUploadExtension.swift
@@ -1,6 +1,7 @@
 import CoreLocation
 import ExtensionFoundation
 import Photos
+import UniformTypeIdentifiers
 import os.lock
 
 @main
@@ -65,11 +66,18 @@ final class BackgroundUploadExtension: PHBackgroundResourceUploadExtension {
 
         for i in 0..<jobs.count where !isCancelled {
             let job = jobs.object(at: i)
+            // Build destination first; if PHAsset is temporarily unavailable (e.g.
+            // PHPhotosError 3300 during iCloud sync), skip this job rather than calling
+            // retry(destination: nil) which strips all custom headers and causes the
+            // proxy to fall back to "upload.jpg".
+            guard let destination = buildDestination(for: job.resource) else {
+                logWarning("Skipping retry for \(job.resource.originalFilename): PHAsset temporarily unavailable")
+                continue
+            }
             try library.performChangesAndWait {
                 guard let req = PHAssetResourceUploadJobChangeRequest(for: job)
                 else { return }
-                // Rebuild destination to refresh auth token if needed
-                req.retry(destination: self.buildDestination(for: job.resource))
+                req.retry(destination: destination)
             }
         }
     }
@@ -316,14 +324,24 @@ final class BackgroundUploadExtension: PHBackgroundResourceUploadExtension {
     }
 
     private func mimeType(for resource: PHAssetResource) -> String {
-        let uti = resource.uniformTypeIdentifier.lowercased()
+        // Use the system UTI registry for accurate MIME type resolution.
+        // Substring matching fails for UTIs like "public.hevc" which contain no
+        // recognisable keyword but map to a well-known MIME type.
+        if let utType = UTType(resource.uniformTypeIdentifier),
+            let mime = utType.preferredMIMEType
+        {
+            return mime
+        }
 
+        // Fallback for unrecognised UTIs
+        let uti = resource.uniformTypeIdentifier.lowercased()
         let mapping: [(check: (String) -> Bool, mime: String)] = [
             ({ $0.contains("jpeg") || $0.contains("jpg") }, "image/jpeg"),
             ({ $0.contains("png") }, "image/png"),
             ({ $0.contains("heic") || $0.contains("heif") }, "image/heic"),
             ({ $0.contains("gif") }, "image/gif"),
             ({ $0.contains("raw") || $0.contains("dng") }, "image/dng"),
+            ({ $0.contains("hevc") }, "video/mp4"),
             ({ $0.contains("mp4") }, "video/mp4"),
             (
                 { $0.contains("quicktime") || $0.contains("mov") },

--- a/YAIIU/Shared/PHAssetResource+ResolvedFilename.swift
+++ b/YAIIU/Shared/PHAssetResource+ResolvedFilename.swift
@@ -39,20 +39,35 @@ extension PHAssetResource {
         _ filename: String, asset: PHAsset
     ) -> String {
         let resources = PHAssetResource.assetResources(for: asset)
-        guard let originalResource = resources.first(where: {
-            ($0.type == .photo || $0.type == .fullSizePhoto)
-                && !$0.originalFilename.hasPrefix("FullSizeRender")
-        }) else {
-            return filename
-        }
-
-        let originalName =
-            (originalResource.originalFilename as NSString).deletingPathExtension
         let editedExtension = (filename as NSString).pathExtension
 
-        if editedExtension.isEmpty {
-            return originalResource.originalFilename
+        // Try photo companion resource first (edited stills, Live Photos)
+        if let photoResource = resources.first(where: {
+            ($0.type == .photo || $0.type == .fullSizePhoto)
+                && !$0.originalFilename.hasPrefix("FullSizeRender")
+        }) {
+            let originalName =
+                (photoResource.originalFilename as NSString).deletingPathExtension
+            if editedExtension.isEmpty {
+                return photoResource.originalFilename
+            }
+            return "\(originalName).\(editedExtension)"
         }
-        return "\(originalName).\(editedExtension)"
+
+        // For pure video assets (e.g. Apple Log HDR exported by third-party camera apps),
+        // fall back to the .video resource to recover the captured filename.
+        if let videoResource = resources.first(where: {
+            $0.type == .video
+                && !$0.originalFilename.hasPrefix("FullSizeRender")
+        }) {
+            let originalName =
+                (videoResource.originalFilename as NSString).deletingPathExtension
+            if editedExtension.isEmpty {
+                return videoResource.originalFilename
+            }
+            return "\(originalName).\(editedExtension)"
+        }
+
+        return filename
     }
 }

--- a/YAIIU/Shared/PHAssetResource+ResolvedFilename.swift
+++ b/YAIIU/Shared/PHAssetResource+ResolvedFilename.swift
@@ -41,33 +41,26 @@ extension PHAssetResource {
         let resources = PHAssetResource.assetResources(for: asset)
         let editedExtension = (filename as NSString).pathExtension
 
-        // Try photo companion resource first (edited stills, Live Photos)
-        if let photoResource = resources.first(where: {
+        // Prefer the photo companion resource (edited stills, Live Photos), then
+        // fall back to the .video resource for pure video assets (e.g. Apple Log
+        // HDR exported by third-party camera apps) to recover the captured filename.
+        let originalResource = resources.first(where: {
             ($0.type == .photo || $0.type == .fullSizePhoto)
                 && !$0.originalFilename.hasPrefix("FullSizeRender")
-        }) {
-            let originalName =
-                (photoResource.originalFilename as NSString).deletingPathExtension
-            if editedExtension.isEmpty {
-                return photoResource.originalFilename
-            }
-            return "\(originalName).\(editedExtension)"
-        }
-
-        // For pure video assets (e.g. Apple Log HDR exported by third-party camera apps),
-        // fall back to the .video resource to recover the captured filename.
-        if let videoResource = resources.first(where: {
+        }) ?? resources.first(where: {
             $0.type == .video
                 && !$0.originalFilename.hasPrefix("FullSizeRender")
-        }) {
-            let originalName =
-                (videoResource.originalFilename as NSString).deletingPathExtension
-            if editedExtension.isEmpty {
-                return videoResource.originalFilename
-            }
-            return "\(originalName).\(editedExtension)"
+        })
+
+        guard let originalResource else {
+            return filename
         }
 
-        return filename
+        if editedExtension.isEmpty {
+            return originalResource.originalFilename
+        }
+        let originalName =
+            (originalResource.originalFilename as NSString).deletingPathExtension
+        return "\(originalName).\(editedExtension)"
     }
 }

--- a/immich-proxy/deployment/immich-proxy/Chart.yaml
+++ b/immich-proxy/deployment/immich-proxy/Chart.yaml
@@ -21,7 +21,7 @@ version: 0.1.0
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.1.1"
+appVersion: "0.1.3"
 
 keywords:
   - immich

--- a/immich-proxy/handlers/background_upload.go
+++ b/immich-proxy/handlers/background_upload.go
@@ -111,6 +111,21 @@ func BackgroundUploadHandler(immichServerURL string) http.HandlerFunc {
 
 		log.Printf("[%s] Received %d bytes of photo data", clientIP, len(photoData))
 
+		// Last-resort safety net: if headers are missing or wrong, use magic byte
+		// detection to prevent video payloads from reaching Immich as image/jpeg.
+		if len(photoData) > 512 &&
+			(metadata.Filename == "upload.jpg" || metadata.ContentType == "application/octet-stream") {
+			detected := http.DetectContentType(photoData)
+			if strings.HasPrefix(detected, "video/") {
+				if metadata.Filename == "upload.jpg" {
+					metadata.Filename = "upload.mov"
+				}
+				metadata.ContentType = detected
+				log.Printf("[%s] Magic byte detection overrode metadata: filename=%s contentType=%s",
+					clientIP, metadata.Filename, metadata.ContentType)
+			}
+		}
+
 		// Create multipart form data for Immich
 		body, contentType, err := createMultipartRequest(metadata, photoData)
 		if err != nil {

--- a/immich-proxy/handlers/background_upload.go
+++ b/immich-proxy/handlers/background_upload.go
@@ -113,12 +113,18 @@ func BackgroundUploadHandler(immichServerURL string) http.HandlerFunc {
 
 		// Last-resort safety net: if headers are missing or wrong, use magic byte
 		// detection to prevent video payloads from reaching Immich as image/jpeg.
-		if len(photoData) > 512 &&
+		if len(photoData) > 0 &&
 			(metadata.Filename == "upload.jpg" || metadata.ContentType == "application/octet-stream") {
 			detected := http.DetectContentType(photoData)
 			if strings.HasPrefix(detected, "video/") {
 				if metadata.Filename == "upload.jpg" {
-					metadata.Filename = "upload.mov"
+					switch detected {
+					case "video/mp4":
+						metadata.Filename = "upload.mp4"
+					default:
+						// .mov is a reasonable default for Apple ecosystem videos
+						metadata.Filename = "upload.mov"
+					}
 				}
 				metadata.ContentType = detected
 				log.Printf("[%s] Magic byte detection overrode metadata: filename=%s contentType=%s",


### PR DESCRIPTION
### **User description**
## Description

This PR is to solve the issue encountered in https://github.com/FawenYo/YAIIU/issues/50.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes video misclassification during background uploads.

- Improves MIME type and filename resolution for videos.

- Prevents header stripping during background job retries.

- Adds a magic-byte detection safety net in the proxy.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph Client [iOS App]
      A["retryFailedJobs()"] --> B{"Asset Available?"};
      B -- "No" --> C["Skip Job"];
      B -- "Yes" --> D["retry(destination)"];
      E["mimeType()"] --> F["Use UTType for MIME"];
      G["resolveEditedFilename()"] --> H["Fallback to .video resource"];
  end

  subgraph Proxy [immich-proxy]
      I[Receive Upload] --> J{"Headers Missing/Incorrect?"};
      J -- "Yes" --> K["Detect Content via Magic Bytes"];
      K --> L["Override Metadata if Video"];
      J -- "No" --> M[Forward to Immich];
      L --> M;
  end

  Client -- "Upload Request" --> I;
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BackgroundUploadExtension.swift</strong><dd><code>Improve background upload job retries and MIME type detection</code></dd></summary>
<hr>

YAIIU/BackgroundUploadExtension/BackgroundUploadExtension.swift

<ul><li>Prevents retrying jobs with a <code>nil</code> destination when a <code>PHAsset</code> is <br>unavailable, which previously stripped custom headers.<br> <li> Skips the job instead, allowing it to be correctly retried in a future <br>session.<br> <li> Replaces fragile substring-based MIME type detection with the more <br>reliable <code>UTType.preferredMIMEType</code>.<br> <li> Adds <code>hevc</code> to the fallback MIME type mapping.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/52/files#diff-5a3187d007baac7d1bc2cf2a8e139843c85e6aaf8d6d0ab0ac2ebfeccb83bb52">+21/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PHAssetResource+ResolvedFilename.swift</strong><dd><code>Enhance filename resolution for edited video assets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/Shared/PHAssetResource+ResolvedFilename.swift

<ul><li>Fixes <code>resolveEditedFilename</code> to correctly find the original filename <br>for pure video assets (e.g., from third-party camera apps).<br> <li> Adds a fallback to check for <code>.video</code> resource types when a <br>corresponding <code>.photo</code> resource is not found.<br> <li> Consolidates filename resolution logic for photo and video resources.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/52/files#diff-a15656e2d8ae4a8738c0c23738718afdb6ddca3cb21878d01489985c3c862740">+14/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>background_upload.go</strong><dd><code>Add magic-byte detection safety net for uploads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

immich-proxy/handlers/background_upload.go

<ul><li>Implements a last-resort safety net for uploads with incorrect or <br>missing headers (e.g., <code>upload.jpg</code>).<br> <li> Uses magic-byte detection (<code>http.DetectContentType</code>) to inspect the file <br>payload.<br> <li> Overrides the filename and content type if a video payload is <br>detected, preventing misclassification by Immich.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/52/files#diff-6a2033e9b0a99c77a21751e95c44ea6650fb4ca4ea6036fcfc3490729b6f652f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Update immich-proxy application version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

immich-proxy/deployment/immich-proxy/Chart.yaml

<ul><li>Bumps the <code>appVersion</code> from <code>0.1.1</code> to <code>0.1.3</code> to reflect the proxy <br>application changes.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/52/files#diff-0d56ccb803acfb1959182b01a9907f9f3f6a9035b009ff0ba78ec21ce56b1058">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

