### PR TITLE
Fix: Sync not-uploaded count with cache and remove filter spinner

### DIFF
--- a/YAIIU/YAIIU/Services/PhotoLibraryManager.swift
+++ b/YAIIU/YAIIU/Services/PhotoLibraryManager.swift
@@ -8,6 +8,12 @@ final class PhotoLibraryManager: ObservableObject {
     @Published var authorizationStatus: PHAuthorizationStatus = .notDetermined
     @Published private(set) var isLoading: Bool = false
     @Published private(set) var assetCount: Int = 0
+
+    /// Local identifiers in fetch order, materialized once per library load so
+    /// callers can derive counts/filters without re-enumerating the lazy
+    /// PHFetchResult (which loads each PHAsset on demand and is very slow for
+    /// large libraries).
+    @Published private(set) var orderedLocalIdentifiers: [String] = []
     
     private var _fetchResult: PHFetchResult<PHAsset>?
     private let fetchResultLock = NSLock()
@@ -61,20 +67,26 @@ final class PhotoLibraryManager: ObservableObject {
     func fetchAssetsAsync() async {
         isLoading = true
         
-        let (result, count) = await Task.detached(priority: .userInitiated) {
+        let (result, count, identifiers) = await Task.detached(priority: .userInitiated) {
             let fetchOptions = PHFetchOptions()
             fetchOptions.sortDescriptors = [NSSortDescriptor(key: "creationDate", ascending: false)]
             fetchOptions.includeHiddenAssets = false
-            
+
             let result = PHAsset.fetchAssets(with: fetchOptions)
-            return (result, result.count)
+            var identifiers: [String] = []
+            identifiers.reserveCapacity(result.count)
+            result.enumerateObjects { asset, _, _ in
+                identifiers.append(asset.localIdentifier)
+            }
+            return (result, result.count, identifiers)
         }.value
-        
+
         fetchResultLock.lock()
         _fetchResult = result
         fetchResultLock.unlock()
-        
+
         assetCount = count
+        orderedLocalIdentifiers = identifiers
         isLoading = false
         
         await triggerFavoriteSync()

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -273,6 +273,7 @@ struct PhotoGridView: View {
     @State private var filteredIndices: [Int] = []
     @State private var cachedNotUploadedCount: Int = 0
     @State private var countRefreshTask: Task<Void, Never>?
+    @State private var recomputeTask: Task<Void, Never>?
     @State private var countComputeVersion: Int = 0
     @State private var isSelectingAll = false
     @State private var selectionTask: Task<Void, Never>?
@@ -403,6 +404,8 @@ struct PhotoGridView: View {
             isSelectingAll = false
             countRefreshTask?.cancel()
             countRefreshTask = nil
+            recomputeTask?.cancel()
+            recomputeTask = nil
             processingTask?.cancel()
             processingTask = nil
         }
@@ -801,10 +804,12 @@ struct PhotoGridView: View {
         let manager = photoLibraryManager
         let hash = hashManager
 
+        recomputeTask?.cancel()
+
         countComputeVersion += 1
         let version = countComputeVersion
 
-        Task.detached(priority: .utility) {
+        recomputeTask = Task(priority: .utility) {
             let (statusCache, identifiers) = await MainActor.run {
                 (hash.syncStatusCache, manager.orderedLocalIdentifiers)
             }
@@ -812,6 +817,7 @@ struct PhotoGridView: View {
             var notUploadedIndices: [Int] = []
             notUploadedIndices.reserveCapacity(identifiers.count / 4)
             for (index, id) in identifiers.enumerated() {
+                if Task.isCancelled { return }
                 if statusCache[id] != .uploaded {
                     notUploadedIndices.append(index)
                 }
@@ -821,7 +827,7 @@ struct PhotoGridView: View {
                 // Discard results from superseded invocations; without this guard
                 // a task that read an earlier cache snapshot could finish last and
                 // overwrite with a stale value (stale-wins race).
-                guard version == self.countComputeVersion else { return }
+                guard !Task.isCancelled, version == self.countComputeVersion else { return }
                 self.cachedNotUploadedCount = notUploadedIndices.count
                 self.filteredIndices = notUploadedIndices
                 if self.currentFilter == .notUploaded {

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -732,11 +732,13 @@ struct PhotoGridView: View {
         if filter == .notUploaded {
             // filteredIndices is kept current by recomputeCounts(); rebuild it
             // off the main thread so tapping the filter never blocks the UI on
-            // large libraries.
+            // large libraries. recomputeCounts() flips refreshToken once the new
+            // indices land, so avoid rebuilding here with the stale set first.
             recomputeCounts()
+        } else {
+            // Other filters use the full set immediately, so rebuild now.
+            refreshToken = UUID()
         }
-        // Force grid rebuild to display the correct set
-        refreshToken = UUID()
     }
 
     private func syncPendingICloudIds() {

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -796,6 +796,7 @@ struct PhotoGridView: View {
     /// orderedLocalIdentifiers array (in-memory) rather than re-enumerating the
     /// lazy PHFetchResult, which is orders of magnitude faster on large
     /// libraries and lets the badge stay in sync with the per-photo icons.
+    @MainActor
     private func recomputeCounts() {
         let manager = photoLibraryManager
         let hash = hashManager

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -401,6 +401,10 @@ struct PhotoGridView: View {
             selectionTask?.cancel()
             selectionTask = nil
             isSelectingAll = false
+            countRefreshTask?.cancel()
+            countRefreshTask = nil
+            processingTask?.cancel()
+            processingTask = nil
         }
         .onChange(of: photoLibraryManager.assetCount) { oldValue, newValue in
             if newValue > 0 && oldValue == 0 {

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -425,8 +425,10 @@ struct PhotoGridView: View {
                 Task {
                     try? await Task.sleep(nanoseconds: 500_000_000)
                     await MainActor.run {
+                        // refreshStatusCache() republishes syncStatusCache, which
+                        // the .onReceive listener already turns into a debounced
+                        // recomputeCounts(), so no direct call is needed here.
                         hashManager.refreshStatusCache()
-                        recomputeCounts()
                     }
                 }
             }

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -272,8 +272,8 @@ struct PhotoGridView: View {
     
     @State private var filteredIndices: [Int] = []
     @State private var cachedNotUploadedCount: Int = 0
-    @State private var isFilteringInProgress = false
-    @State private var filterCacheVersion: Int = 0
+    @State private var countRefreshTask: Task<Void, Never>?
+    @State private var countComputeVersion: Int = 0
     @State private var isSelectingAll = false
     @State private var selectionTask: Task<Void, Never>?
     
@@ -415,10 +415,7 @@ struct PhotoGridView: View {
                     
                     await MainActor.run {
                         guard !Task.isCancelled, !photoLibraryManager.isLoading else { return }
-                        updateNotUploadedCount()
-                        if currentFilter == .notUploaded {
-                            refreshFilterCache()
-                        }
+                        recomputeCounts()
                     }
                 }
             }
@@ -429,22 +426,37 @@ struct PhotoGridView: View {
                     try? await Task.sleep(nanoseconds: 500_000_000)
                     await MainActor.run {
                         hashManager.refreshStatusCache()
-                        updateNotUploadedCount()
-                        if currentFilter == .notUploaded {
-                            refreshFilterCache()
-                        }
+                        recomputeCounts()
                     }
                 }
             }
         }
         .onChange(of: hashManager.isProcessing) { oldValue, newValue in
             if oldValue == true && newValue == false {
-                updateNotUploadedCount()
-                if currentFilter == .notUploaded {
-                    refreshFilterCache()
-                }
                 syncPendingICloudIds()
             }
+        }
+        // The count must track the same source as the per-photo icons
+        // (syncStatusCache). finishProcessing() flips isProcessing before the
+        // authoritative DB reload lands, so reacting to the cache itself ensures
+        // the count converges to the final state instead of a mid-flight snapshot.
+        // During hashing the cache mutates per asset, so coalesce the bursts into
+        // a single recompute after activity settles to avoid main-thread churn.
+        // Use the same publisher the per-photo icons subscribe to (onReceive),
+        // not onChange(of:). onChange only fires when SwiftUI's diff sees a new
+        // value during body re-eval, which can be skipped; onReceive fires on
+        // every publish, so the count tracks the icons exactly.
+        .onReceive(hashManager.$syncStatusCache.receive(on: RunLoop.main)) { _ in
+            scheduleCountRefresh()
+        }
+    }
+
+    private func scheduleCountRefresh() {
+        countRefreshTask?.cancel()
+        countRefreshTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 250_000_000)
+            guard !Task.isCancelled else { return }
+            recomputeCounts()
         }
     }
     
@@ -516,17 +528,7 @@ struct PhotoGridView: View {
                     filterIndicatorView
                 }
                 
-                ZStack {
-                    simpleGridView
-                    
-                    if isFilteringInProgress && currentFilter != .all {
-                        Color.black.opacity(0.3)
-                            .ignoresSafeArea()
-                        ProgressView()
-                            .scaleEffect(1.5)
-                            .tint(.white)
-                    }
-                }
+                simpleGridView
             }
             .frame(width: geometry.size.width, height: geometry.size.height)
             .onAppear { gridContainerWidth = geometry.size.width }
@@ -674,14 +676,9 @@ struct PhotoGridView: View {
         HStack {
             Image(systemName: currentFilter.iconName)
                 .foregroundColor(.orange)
-            if isFilteringInProgress {
-                ProgressView()
-                    .scaleEffect(0.7)
-            } else {
-                Text(L10n.PhotoGrid.filterActive(displayCount))
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-            }
+            Text(L10n.PhotoGrid.filterActive(displayCount))
+                .font(.subheadline)
+                .foregroundColor(.secondary)
             Spacer()
             Button {
                 applyFilter(.all)
@@ -733,54 +730,15 @@ struct PhotoGridView: View {
         currentFilter = filter
         
         if filter == .notUploaded {
-            refreshFilterCache()
-        } else {
-            // Force grid rebuild when switching back to "all"
-            refreshToken = UUID()
+            // filteredIndices is kept current by recomputeCounts(); rebuild it
+            // off the main thread so tapping the filter never blocks the UI on
+            // large libraries.
+            recomputeCounts()
         }
+        // Force grid rebuild to display the correct set
+        refreshToken = UUID()
     }
-    
-    private func refreshFilterCache() {
-        guard !isFilteringInProgress else { return }
-        
-        isFilteringInProgress = true
-        filterCacheVersion += 1
-        let currentVersion = filterCacheVersion
-        
-        let manager = photoLibraryManager
-        let hash = hashManager
-        
-        // Capture statusCache inside the Task to get the latest snapshot
-        Task.detached(priority: .userInitiated) {
-            // Read latest values atomically to ensure consistency
-            let (statusCache, totalCount, fetchResult) = await MainActor.run {
-                (hash.syncStatusCache, manager.assetCount, manager.fetchResult)
-            }
-            
-            var indices: [Int] = []
-            indices.reserveCapacity(totalCount / 4)
-            
-            if let fetchResult = fetchResult {
-                fetchResult.enumerateObjects { (asset, index, _) in
-                    let status = statusCache[asset.localIdentifier] ?? .pending
-                    if status != .uploaded {
-                        indices.append(index)
-                    }
-                }
-            }
-            
-            await MainActor.run {
-                guard currentVersion == self.filterCacheVersion else { return }
-                
-                self.filteredIndices = indices
-                self.cachedNotUploadedCount = indices.count
-                self.isFilteringInProgress = false
-                // Force grid rebuild to display correct thumbnails
-                self.refreshToken = UUID()
-            }
-        }
-    }
-    
+
     private func syncPendingICloudIds() {
         let updates = hashManager.pendingICloudIdUpdates
         guard !updates.isEmpty else { return }
@@ -825,33 +783,41 @@ struct PhotoGridView: View {
         }
     }
 
-    private func updateNotUploadedCount() {
+    /// Single off-main pass that derives both the not-uploaded count and the
+    /// filtered index set from the current syncStatusCache. Iterates the cached
+    /// orderedLocalIdentifiers array (in-memory) rather than re-enumerating the
+    /// lazy PHFetchResult, which is orders of magnitude faster on large
+    /// libraries and lets the badge stay in sync with the per-photo icons.
+    private func recomputeCounts() {
         let manager = photoLibraryManager
         let hash = hashManager
-        
+
+        countComputeVersion += 1
+        let version = countComputeVersion
+
         Task.detached(priority: .utility) {
-            // Read latest values atomically to ensure consistency
-            let (statusCache, totalCount, fetchResult) = await MainActor.run {
-                (hash.syncStatusCache, manager.assetCount, manager.fetchResult)
+            let (statusCache, identifiers) = await MainActor.run {
+                (hash.syncStatusCache, manager.orderedLocalIdentifiers)
             }
-            
-            guard let fetchResult = fetchResult else {
-                await MainActor.run {
-                    self.cachedNotUploadedCount = totalCount
-                }
-                return
-            }
-            
-            var uploadedCount = 0
-            fetchResult.enumerateObjects { (asset, _, _) in
-                if statusCache[asset.localIdentifier] == .uploaded {
-                    uploadedCount += 1
+
+            var notUploadedIndices: [Int] = []
+            notUploadedIndices.reserveCapacity(identifiers.count / 4)
+            for (index, id) in identifiers.enumerated() {
+                if statusCache[id] != .uploaded {
+                    notUploadedIndices.append(index)
                 }
             }
-            
-            let notUploadedCount = totalCount - uploadedCount
+
             await MainActor.run {
-                self.cachedNotUploadedCount = notUploadedCount
+                // Discard results from superseded invocations; without this guard
+                // a task that read an earlier cache snapshot could finish last and
+                // overwrite with a stale value (stale-wins race).
+                guard version == self.countComputeVersion else { return }
+                self.cachedNotUploadedCount = notUploadedIndices.count
+                self.filteredIndices = notUploadedIndices
+                if self.currentFilter == .notUploaded {
+                    self.refreshToken = UUID()
+                }
             }
         }
     }
@@ -909,11 +875,8 @@ struct PhotoGridView: View {
         firstRowTopOffset = 0
         
         refreshToken = UUID()
-        
-        updateNotUploadedCount()
-        if currentFilter == .notUploaded {
-            refreshFilterCache()
-        }
+
+        recomputeCounts()
     }
     
     


### PR DESCRIPTION
### **User description**
## Description

This PR fixes the incorrect not-uploaded count issue.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes stale "not-uploaded" count by making it reactive to cache changes.

- Removes the filter loading spinner, improving UI responsiveness.

- Consolidates count and filter logic into a more efficient function.

- Cancels background tasks on view disappearance to prevent resource leaks.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  subgraph PhotoGridView
    A[hashManager.$syncStatusCache] -- "publishes change" --> B["onReceive listener"];
    B -- "debounces via" --> C[scheduleCountRefresh];
    C -- "starts background task" --> D[recomputeCounts];
  end

  subgraph Data Sources
    E[photoLibraryManager.orderedLocalIdentifiers]
  end

  D -- "reads" --> A;
  D -- "reads" --> E;
  D -- "updates" --> F["@State cachedNotUploadedCount"];
  D -- "updates" --> G["@State filteredIndices"];
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoLibraryManager.swift</strong><dd><code>Cache photo local identifiers for improved performance</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/PhotoLibraryManager.swift

<ul><li>Adds a new <code>@Published</code> property <code>orderedLocalIdentifiers</code> to cache asset <br>identifiers.<br> <li> Populates this array once when assets are fetched in <code>fetchAssetsAsync</code>.<br> <li> This avoids repeated, slow enumeration of <code>PHFetchResult</code> in other parts <br>of the app.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/53/files#diff-3f331b5e990d7865cbd9062fe9c97a25742cabb905a37f5a4186b0a7175a133c">+17/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Refactor state management for reactive updates and performance gains</code></dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>Replaces manual count updates with a reactive system that listens to <br><code>syncStatusCache</code> changes, ensuring the count is always up-to-date.<br> <li> Removes the filter loading spinner (<code>isFilteringInProgress</code>) and <br>simplifies the UI by making filtering synchronous and faster.<br> <li> Introduces a new <code>recomputeCounts</code> function that efficiently calculates <br>the not-uploaded count and filtered indices using the cached <br><code>orderedLocalIdentifiers</code>.<br> <li> Adds cancellation for background tasks (<code>countRefreshTask</code>, <br><code>recomputeTask</code>, <code>processingTask</code>) in <code>onDisappear</code> to prevent memory leaks <br>and unnecessary work.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/53/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+81/-103</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

