### PR TITLE
Fix: Selection toolbar overflow i18n

### DIFF
--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -348,18 +348,14 @@ struct PhotoGridView: View {
                             .disabled(displayCount == 0)
                         }
                     } else {
-                        ToolbarItem(placement: .bottomBar) {
+                        ToolbarItemGroup(placement: .bottomBar) {
                             Button(L10n.PhotoGrid.selectAllNotUploaded) {
                                 selectAllNotUploaded()
                             }
                             .disabled(hashManager.isProcessing || isSelectingAll)
-                        }
 
-                        ToolbarItem(placement: .bottomBar) {
                             Spacer()
-                        }
 
-                        ToolbarItem(placement: .bottomBar) {
                             Button(L10n.PhotoGrid.upload(selectedAssets.count)) {
                                 showingUploadConfirmation = true
                             }
@@ -378,7 +374,7 @@ struct PhotoGridView: View {
             }
             .navigationViewStyle(.stack)
             .toolbar((showingPhotoDetail || isSelectionMode) ? .hidden : .visible, for: .tabBar)
-            .animation(.easeInOut(duration: 0.2), value: showingPhotoDetail)
+            .animation(.easeInOut(duration: 0.2), value: showingPhotoDetail || isSelectionMode)
             
             if showingPhotoDetail && displayCount > 0 {
                 PhotoDetailView(

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -344,15 +344,17 @@ struct PhotoGridView: View {
                         }
                     }
                     
-                    if !isSelectionMode {
-                        ToolbarItem(placement: .navigationBarTrailing) {
+                    ToolbarItem(placement: .navigationBarTrailing) {
+                        if !isSelectionMode {
                             Button(L10n.PhotoGrid.select) {
                                 isSelectionMode = true
                             }
                             .disabled(displayCount == 0)
                         }
-                    } else {
-                        ToolbarItemGroup(placement: .bottomBar) {
+                    }
+
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        if isSelectionMode {
                             Button(L10n.PhotoGrid.selectAllNotUploaded) {
                                 selectAllNotUploaded()
                             }

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -340,23 +340,30 @@ struct PhotoGridView: View {
                         }
                     }
                     
-                    ToolbarItem(placement: .navigationBarTrailing) {
-                        if !isSelectionMode {
+                    if !isSelectionMode {
+                        ToolbarItem(placement: .navigationBarTrailing) {
                             Button(L10n.PhotoGrid.select) {
                                 isSelectionMode = true
                             }
                             .disabled(displayCount == 0)
-                        } else {
-                            HStack(spacing: 12) {
+                        }
+                    } else {
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Menu {
                                 Button(L10n.PhotoGrid.selectAllNotUploaded) {
                                     selectAllNotUploaded()
                                 }
                                 .disabled(hashManager.isProcessing || isSelectingAll)
-                                Button(L10n.PhotoGrid.upload(selectedAssets.count)) {
-                                    showingUploadConfirmation = true
-                                }
-                                .disabled(selectedAssets.isEmpty)
+                            } label: {
+                                Image(systemName: "ellipsis.circle")
                             }
+                        }
+
+                        ToolbarItem(placement: .navigationBarTrailing) {
+                            Button(L10n.PhotoGrid.upload(selectedAssets.count)) {
+                                showingUploadConfirmation = true
+                            }
+                            .disabled(selectedAssets.isEmpty)
                         }
                     }
                 }

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -305,7 +305,11 @@ struct PhotoGridView: View {
             return filteredIndices.count
         }
     }
-    
+
+    private var isTabBarHidden: Bool {
+        showingPhotoDetail || isSelectionMode
+    }
+
     var body: some View {
         ZStack {
             NavigationView {
@@ -373,8 +377,8 @@ struct PhotoGridView: View {
                 }
             }
             .navigationViewStyle(.stack)
-            .toolbar((showingPhotoDetail || isSelectionMode) ? .hidden : .visible, for: .tabBar)
-            .animation(.easeInOut(duration: 0.2), value: showingPhotoDetail || isSelectionMode)
+            .toolbar(isTabBarHidden ? .hidden : .visible, for: .tabBar)
+            .animation(.easeInOut(duration: 0.2), value: isTabBarHidden)
             
             if showingPhotoDetail && displayCount > 0 {
                 PhotoDetailView(

--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -348,18 +348,18 @@ struct PhotoGridView: View {
                             .disabled(displayCount == 0)
                         }
                     } else {
-                        ToolbarItem(placement: .navigationBarTrailing) {
-                            Menu {
-                                Button(L10n.PhotoGrid.selectAllNotUploaded) {
-                                    selectAllNotUploaded()
-                                }
-                                .disabled(hashManager.isProcessing || isSelectingAll)
-                            } label: {
-                                Image(systemName: "ellipsis.circle")
+                        ToolbarItem(placement: .bottomBar) {
+                            Button(L10n.PhotoGrid.selectAllNotUploaded) {
+                                selectAllNotUploaded()
                             }
+                            .disabled(hashManager.isProcessing || isSelectingAll)
                         }
 
-                        ToolbarItem(placement: .navigationBarTrailing) {
+                        ToolbarItem(placement: .bottomBar) {
+                            Spacer()
+                        }
+
+                        ToolbarItem(placement: .bottomBar) {
                             Button(L10n.PhotoGrid.upload(selectedAssets.count)) {
                                 showingUploadConfirmation = true
                             }
@@ -377,7 +377,7 @@ struct PhotoGridView: View {
                 }
             }
             .navigationViewStyle(.stack)
-            .toolbar(showingPhotoDetail ? .hidden : .visible, for: .tabBar)
+            .toolbar((showingPhotoDetail || isSelectionMode) ? .hidden : .visible, for: .tabBar)
             .animation(.easeInOut(duration: 0.2), value: showingPhotoDetail)
             
             if showingPhotoDetail && displayCount > 0 {


### PR DESCRIPTION
### **User description**
## Description

This PR is to fix the error reported in the issue https://github.com/FawenYo/YAIIU/issues/57 that selection button in the photo library is not working in some languages.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fixes unresponsive selection buttons caused by toolbar overflow.

- Relocates selection actions to a new bottom toolbar.

- Hides the main tab bar during selection mode.

- Refactors tab bar visibility logic for clarity.


___

### Diagram Walkthrough


```mermaid
flowchart LR
    subgraph "Old Layout (Top Bar)"
        A["ToolbarItem with HStack"] -- "Overflows with long text" --> B["Unresponsive '...' Button"]
    end
    subgraph "New Layout (Bottom Bar)"
        C["ToolbarItemGroup"] -- "Uses full width" --> D["Responsive Buttons"]
    end

    A -- "is replaced by" --> C
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Relocate selection actions to bottom toolbar to fix overflow bug</code></dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>Moves selection mode buttons (<code>Select all not uploaded</code>, <code>Upload</code>) from <br>the top navigation bar to a new bottom toolbar.<br> <li> Fixes a bug where buttons became unresponsive due to layout overflow <br>with long localized strings.<br> <li> Hides the main tab bar when entering selection mode to accommodate the <br>new bottom toolbar.<br> <li> Introduces the <code>isTabBarHidden</code> computed property to centralize <br>visibility logic.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/62/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+22/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

