### PR TITLE
Feat: Restore onboarding background upload toggle

### DIFF
--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -428,11 +428,19 @@ struct PhotoGridView: View {
                 processingTask?.cancel()
                 processingTask = Task(priority: .background) {
                     if Task.isCancelled { return }
-                    
+
                     await MainActor.run {
                         guard !Task.isCancelled, !photoLibraryManager.isLoading else { return }
                         recomputeCounts()
                     }
+                }
+
+                // performAutoSync() on first appear can race ahead of the initial
+                // asset fetch and no-op in startBackgroundProcessing() because
+                // assetCount was still 0. Retry now that assets have loaded so
+                // upload-status icons populate without requiring a manual refresh.
+                if !hashManager.isProcessing {
+                    startBackgroundProcessing()
                 }
             }
         }

--- a/YAIIU/YAIIU/Views/PhotoPermissionView.swift
+++ b/YAIIU/YAIIU/Views/PhotoPermissionView.swift
@@ -209,7 +209,7 @@ struct PhotoPermissionView: View {
             } catch {
                 await MainActor.run {
                     backgroundUploadLoading = false
-                    backgroundUploadEnabled = manager.isEnabled
+                    backgroundUploadEnabled = !enabled
                     backgroundUploadError = error.localizedDescription
                 }
             }

--- a/YAIIU/YAIIU/Views/PhotoPermissionView.swift
+++ b/YAIIU/YAIIU/Views/PhotoPermissionView.swift
@@ -10,8 +10,17 @@ struct PhotoPermissionView: View {
     @State private var status: PHAuthorizationStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
     @State private var isRequesting = false
 
+    @State private var backgroundUploadEnabled = false
+    @State private var backgroundUploadLoading = false
+    @State private var backgroundUploadError: String?
+
     private var hasFullAccess: Bool { status == .authorized }
     private var needsUpgrade: Bool { status == .limited || status == .denied || status == .restricted }
+
+    private var backgroundUploadSupported: Bool {
+        if #available(iOS 26.1, *) { return true }
+        return false
+    }
 
     var body: some View {
         VStack(spacing: 32) {
@@ -37,6 +46,10 @@ struct PhotoPermissionView: View {
                 warningCard
             }
 
+            if hasFullAccess && backgroundUploadSupported {
+                backgroundUploadCard
+            }
+
             Spacer()
 
             actionSection
@@ -44,20 +57,53 @@ struct PhotoPermissionView: View {
         .padding(.horizontal, 24)
         .padding(.vertical, 40)
         .onAppear {
-            refreshStatus()
+            status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+            loadBackgroundUploadStatus()
         }
         .onReceive(NotificationCenter.default.publisher(for: UIApplication.willEnterForegroundNotification)) { _ in
-            refreshStatus()
+            status = PHPhotoLibrary.authorizationStatus(for: .readWrite)
+            loadBackgroundUploadStatus()
         }
     }
 
-    private func refreshStatus() {
-        let currentStatus = PHPhotoLibrary.authorizationStatus(for: .readWrite)
-        if currentStatus == .authorized {
-            settingsManager.completePhotoPermission()
-        } else {
-            status = currentStatus
+    private var backgroundUploadCard: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Toggle(isOn: $backgroundUploadEnabled) {
+                HStack {
+                    Image(systemName: "arrow.up.circle.badge.clock")
+                        .foregroundColor(.blue)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(L10n.BackgroundUpload.title)
+                            .foregroundColor(.primary)
+                        Text(backgroundUploadEnabled ? L10n.BackgroundUpload.enabled : L10n.BackgroundUpload.disabled)
+                            .font(.caption)
+                            .foregroundColor(backgroundUploadEnabled ? .green : .secondary)
+                    }
+                }
+            }
+            .disabled(backgroundUploadLoading)
+            .onChange(of: backgroundUploadEnabled) { _, newValue in
+                toggleBackgroundUpload(enabled: newValue)
+            }
+
+            Text(L10n.BackgroundUpload.description)
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            if let error = backgroundUploadError {
+                HStack {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundColor(.red)
+                    Text(error)
+                        .font(.caption)
+                        .foregroundColor(.red)
+                }
+            }
         }
+        .padding()
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color(.systemGray6))
+        .cornerRadius(12)
     }
 
     private var warningCard: some View {
@@ -122,9 +168,7 @@ struct PhotoPermissionView: View {
             DispatchQueue.main.async {
                 self.status = newStatus
                 self.isRequesting = false
-                if newStatus == .authorized {
-                    self.settingsManager.completePhotoPermission()
-                }
+                self.loadBackgroundUploadStatus()
             }
         }
     }
@@ -132,6 +176,43 @@ struct PhotoPermissionView: View {
     private func openSettings() {
         if let url = URL(string: UIApplication.openSettingsURLString) {
             UIApplication.shared.open(url)
+        }
+    }
+
+    private func loadBackgroundUploadStatus() {
+        if #available(iOS 26.1, *) {
+            let manager = BackgroundUploadManager.shared
+            backgroundUploadEnabled = manager.isEnabled
+            backgroundUploadError = manager.errorMessage
+        }
+    }
+
+    private func toggleBackgroundUpload(enabled: Bool) {
+        guard #available(iOS 26.1, *) else { return }
+        let manager = BackgroundUploadManager.shared
+        guard enabled != manager.isEnabled else { return }
+
+        backgroundUploadLoading = true
+        backgroundUploadError = nil
+
+        Task {
+            do {
+                if enabled {
+                    try await manager.enableBackgroundUpload()
+                } else {
+                    try await manager.disableBackgroundUpload()
+                }
+                await MainActor.run {
+                    backgroundUploadLoading = false
+                    loadBackgroundUploadStatus()
+                }
+            } catch {
+                await MainActor.run {
+                    backgroundUploadLoading = false
+                    backgroundUploadEnabled = manager.isEnabled
+                    backgroundUploadError = error.localizedDescription
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
### **User description**
## Description

Toggle background upload function in init setup


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Restores the background upload toggle to the onboarding screen

- Removes auto-advance after granting photo permission

- Fixes a race condition for initial upload status sync


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User grants photo permission"] --> B["PhotoPermissionView with upload toggle is shown"]
  B --> C{"User interacts with toggle"}
  C -->|Enable| D["Background upload is enabled via manager"]
  B --> E["User proceeds with onboarding"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Fix race condition by syncing upload status after assets load</code></dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>Triggers <code>startBackgroundProcessing()</code> after the initial asset fetch <br>completes.<br> <li> Fixes a race condition where the initial sync could run before assets <br>were loaded, failing to show upload statuses.<br> <li> Ensures cloud icons for upload status populate automatically without <br>requiring a manual refresh.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/63/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+9/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoPermissionView.swift</strong><dd><code>Restore background upload toggle to the onboarding permission screen</code></dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoPermissionView.swift

<ul><li>Re-introduces a toggle to enable background uploads on the photo <br>permission screen.<br> <li> Removes the logic that automatically advanced the user after granting <br>permission, allowing them to interact with the new toggle.<br> <li> Adds UI and state management for the background upload feature, <br>including loading and error states.<br> <li> The feature is conditionally available based on an OS version check <br>(<code>iOS 26.1</code>).</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/63/files#diff-4215f738c09fef729b565cab39725b5e9f2a36f5d29fa55e4ae2ebd5967f3bc1">+92/-11</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

