### PR TITLE
docs(proxy): warn that published images predate the account-login switch

### DIFF
--- a/immich-proxy/README.md
+++ b/immich-proxy/README.md
@@ -89,13 +89,14 @@ go run .
 
 ### Using Docker
 
-```bash
-docker run -p 8080:8080 \
-  -e IMMICH_SERVER_URL=http://your-immich-server:2283 \
-  fawenyo/immich-proxy:0.1.0
-```
+> [!IMPORTANT]
+> The currently published image tags are older than this source tree and do **not**
+> forward the `Authorization` header. Since the app switched from API-key login to
+> account login, background uploads through those images fail with
+> `401 {"message":"Authentication required"}`.
+> Until a new image is published, build from source as shown below.
 
-Or build your own:
+Build from source (recommended):
 
 ```bash
 cd immich-proxy
@@ -103,6 +104,14 @@ docker build -t immich-proxy .
 docker run -p 8080:8080 \
   -e IMMICH_SERVER_URL=http://your-immich-server:2283 \
   immich-proxy
+```
+
+Published image:
+
+```bash
+docker run -p 8080:8080 \
+  -e IMMICH_SERVER_URL=http://your-immich-server:2283 \
+  fawenyo/immich-proxy:0.1.0
 ```
 
 ### Using Helm (Kubernetes)


### PR DESCRIPTION
### **User description**
Follow-up to #69.

The published proxy image tags are older than this source tree. They forward `x-api-key` and drop `Authorization`, while the app has since moved from API-key login to account login and sends `Authorization: Bearer <token>` (`BackgroundUploadExtension.swift:252`). Anyone following the README therefore gets:

```
Immich response status: 401, body: {"message":"Authentication required"}
```

Current `main` already forwards the header correctly (`handlers/background_upload.go:156-158`), so a source build works. Verified: the same background upload that failed twice with 401 returned `201 {"status":"created"}` after switching to a self-built image.

This PR only touches the README:

- adds a note that the published tags cannot work with the current app
- moves the source build up as the recommended path
- keeps the published-image command, just below

Happy to drop the note again as soon as a new image is published — at that point the README can simply point at the new tag.


___

### **PR Type**
Documentation


___

### **Description**
- Warn about outdated published Docker images.

- Explain 401 errors during background uploads.

- Recommend building Docker image from source.

- Reorder README instructions prioritizing source builds.


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Docker setup instructions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

immich-proxy/README.md

<ul><li>Added a warning about 401 errors with published images.<br> <li> Reordered instructions to recommend building from source.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/70/files#diff-b660c684a70e764c2a051d0263c8463289bc7e23a1a30b36c788d6365c711ccf">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

