### PR TITLE
Fix: Prevent Progress Indicator Clipping

### DIFF
--- a/YAIIU/YAIIU/Views/PhotoGridView.swift
+++ b/YAIIU/YAIIU/Views/PhotoGridView.swift
@@ -492,6 +492,7 @@ struct PhotoGridView: View {
             HStack(spacing: 6) {
                 ProgressView()
                     .scaleEffect(0.7)
+                    .padding(.vertical, 2)
                 
                 Text(getProcessingStatusText())
                     .font(.system(size: 12))


### PR DESCRIPTION
### **User description**
## Description

This PR is to fix the progress indicator being clipped in some languages.


___

### **PR Type**
Bug fix


___

### **Description**
- Add vertical padding around processing progress indicator

- Prevent clipping in localized status layouts


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PhotoGridView.swift</strong><dd><code>Add Padding To Processing Progress Indicator</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Views/PhotoGridView.swift

<ul><li>Adds vertical padding to the scaled <code>ProgressView</code>.<br> <li> Prevents processing indicators from being clipped.</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/73/files#diff-95ffe9fd407c4f419b1d9b16cc27ca7cfffaf7c09a8f347a23f2f9b5a6cf1a1f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

