### PR TITLE
Fix: Reduce Peak Memory Usage

### DIFF
--- a/YAIIU/YAIIU.xcodeproj/project.pbxproj
+++ b/YAIIU/YAIIU.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		BC7F352A2EFED8F200747537 /* SharedSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7F35252EFED8F200747537 /* SharedSettings.swift */; };
         BU0000010000000000000001 /* BackgroundUploadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BU0000020000000000000001 /* BackgroundUploadPolicy.swift */; };
         TS0000140000000000000001 /* BackgroundUploadPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TS0000150000000000000001 /* BackgroundUploadPolicyTests.swift */; };
+		TS0000160000000000000001 /* HashPipelinePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TS0000170000000000000001 /* HashPipelinePolicyTests.swift */; };
         BU0000030000000000000001 /* BackgroundUploadPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = BU0000020000000000000001 /* BackgroundUploadPolicy.swift */; };
 		BC7F352B2EFED90000747537 /* SharedLogTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7F352C2EFED90000747537 /* SharedLogTypes.swift */; };
 		BC7F352D2EFED90000747537 /* SharedLogTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC7F352C2EFED90000747537 /* SharedLogTypes.swift */; };
@@ -137,6 +138,7 @@
 		BC7F35252EFED8F200747537 /* SharedSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedSettings.swift; sourceTree = "<group>"; };
         BU0000020000000000000001 /* BackgroundUploadPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundUploadPolicy.swift; sourceTree = "<group>"; };
         TS0000150000000000000001 /* BackgroundUploadPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundUploadPolicyTests.swift; sourceTree = "<group>"; };
+		TS0000170000000000000001 /* HashPipelinePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashPipelinePolicyTests.swift; sourceTree = "<group>"; };
 		BC7F352C2EFED90000747537 /* SharedLogTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedLogTypes.swift; sourceTree = "<group>"; };
 		RF0000020000000000000001 /* PHAssetResource+ResolvedFilename.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PHAssetResource+ResolvedFilename.swift"; sourceTree = "<group>"; };
 		DB0000020000000000000001 /* SQLiteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SQLiteConnection.swift; sourceTree = "<group>"; };
@@ -385,6 +387,7 @@
 				TS0000110000000000000001 /* ServerAssetRepositoryTests.swift */,
 				TS0000130000000000000001 /* ServerAssetSyncPersistenceTests.swift */,
                 TS0000150000000000000001 /* BackgroundUploadPolicyTests.swift */,
+				TS0000170000000000000001 /* HashPipelinePolicyTests.swift */,
 			);
 			path = YAIIUTests;
 			sourceTree = "<group>";
@@ -590,6 +593,7 @@
 				TS0000100000000000000001 /* ServerAssetRepositoryTests.swift in Sources */,
 				TS0000120000000000000001 /* ServerAssetSyncPersistenceTests.swift in Sources */,
                 TS0000140000000000000001 /* BackgroundUploadPolicyTests.swift in Sources */,
+				TS0000160000000000000001 /* HashPipelinePolicyTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -13,21 +13,28 @@ enum HashPipelinePolicy {
         }
     }
 
-    struct RunState {
-        private(set) var currentRunID: UUID?
+    final class RunState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var currentRunID: UUID?
 
-        mutating func begin() -> UUID {
+        func begin() -> UUID {
             let runID = UUID()
+            lock.lock()
             currentRunID = runID
+            lock.unlock()
             return runID
         }
 
-        mutating func invalidate() {
+        func invalidate() {
+            lock.lock()
             currentRunID = nil
+            lock.unlock()
         }
 
         func owns(_ runID: UUID) -> Bool {
-            currentRunID == runID
+            lock.lock()
+            defer { lock.unlock() }
+            return currentRunID == runID
         }
     }
 }
@@ -67,7 +74,7 @@ class HashManager: ObservableObject {
     private var hashTask: Task<Void, Never>?
     private var checkTask: Task<Void, Never>?
     private var matchingTask: Task<Void, Never>?
-    private var runState = HashPipelinePolicy.RunState()
+    private let runState = HashPipelinePolicy.RunState()
     
     private init() {
         loadCachedStatus()
@@ -620,8 +627,7 @@ class HashManager: ObservableObject {
         runState.invalidate()
         shouldStop = true
         isStopping = true
-        isProcessing = false
-        statusMessage = ""
+        statusMessage = "Stopping..."
 
         let tasks = [hashTask, checkTask, matchingTask].compactMap { $0 }
         tasks.forEach { $0.cancel() }
@@ -633,9 +639,11 @@ class HashManager: ObservableObject {
 
             guard let self, self.isStopping else { return }
             await self.refreshStatusCacheAsync()
+            self.isProcessing = false
             self.isHashingActive = false
             self.isCheckingActive = false
             self.isStopping = false
+            self.statusMessage = ""
         }
     }
 

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -2,6 +2,36 @@ import Foundation
 import Photos
 import Combine
 
+enum HashPipelinePolicy {
+    static func processSerially<Element>(
+        _ elements: [Element],
+        operation: (Element) async -> Void
+    ) async {
+        for element in elements {
+            guard !Task.isCancelled else { break }
+            await operation(element)
+        }
+    }
+
+    struct RunState {
+        private(set) var currentRunID: UUID?
+
+        mutating func begin() -> UUID {
+            let runID = UUID()
+            currentRunID = runID
+            return runID
+        }
+
+        mutating func invalidate() {
+            currentRunID = nil
+        }
+
+        func owns(_ runID: UUID) -> Bool {
+            currentRunID == runID
+        }
+    }
+}
+
 class HashManager: ObservableObject {
     static let shared = HashManager()
     
@@ -23,11 +53,8 @@ class HashManager: ObservableObject {
     private var isHashingActive = false
     private var isCheckingActive = false
     
-    private let hashQueue = DispatchQueue(label: "com.fawenyo.yaiiu.hash", qos: .utility)
     private let checkQueue = DispatchQueue(label: "com.fawenyo.yaiiu.check", qos: .utility)
     
-    /// Number of concurrent hash calculations (adjust based on device capability)
-    private let hashConcurrency = 3
     /// Number of concurrent server checks
     private let checkConcurrency = 5
     /// Batch size for server checks
@@ -38,6 +65,8 @@ class HashManager: ObservableObject {
     private var shouldStop = false
     private var hashTask: Task<Void, Never>?
     private var checkTask: Task<Void, Never>?
+    private var matchingTask: Task<Void, Never>?
+    private var runState = HashPipelinePolicy.RunState()
     
     private init() {
         loadCachedStatus()
@@ -65,7 +94,8 @@ class HashManager: ObservableObject {
     private func loadCachedStatus() {
         DatabaseManager.shared.getAllSyncStatusAsync { [weak self] statusMap in
             DispatchQueue.main.async {
-                self?.syncStatusCache = statusMap
+                guard let self, !self.isProcessing else { return }
+                self.syncStatusCache = statusMap
             }
         }
     }
@@ -79,6 +109,7 @@ class HashManager: ObservableObject {
     func startBackgroundProcessing(identifiers: [String]) {
         guard !isHashingActive && !isCheckingActive else { return }
 
+        let runID = runState.begin()
         shouldStop = false
         isProcessing = true
         iCloudIdMatchCount = 0
@@ -92,14 +123,22 @@ class HashManager: ObservableObject {
             logInfo("Hash cache lookup complete: total=\(identifiers.count), needingHash=\(needingHash.count)", category: .hash)
 
             Task { @MainActor in
+                guard self.isCurrentRun(runID), !self.shouldStop else {
+                    self.finishProcessing(runID: runID)
+                    return
+                }
                 if needingHash.isEmpty {
                     self.statusMessage = "Checking cloud status..."
-                    self.startServerCheck()
+                    self.startServerCheck(runID: runID)
                 } else {
-                    self.tryICloudIdMatching(identifiers: needingHash) { remainingNeedingHash in
+                    self.tryICloudIdMatching(identifiers: needingHash, runID: runID) { remainingNeedingHash in
+                        guard self.isCurrentRun(runID), !self.shouldStop else {
+                            self.finishProcessing(runID: runID)
+                            return
+                        }
                         if remainingNeedingHash.isEmpty {
                             self.statusMessage = "Checking cloud status..."
-                            self.startServerCheck()
+                            self.startServerCheck(runID: runID)
                         } else {
                             self.processingQueue = remainingNeedingHash
                             self.totalAssetsToProcess = remainingNeedingHash.count
@@ -107,7 +146,7 @@ class HashManager: ObservableObject {
                             self.processingProgress = 0
                             self.statusMessage = "Analyzing photos (0/\(remainingNeedingHash.count))..."
 
-                            self.processHashItemsParallel()
+                            self.processHashItemsSerially(runID: runID)
                         }
                     }
                 }
@@ -115,8 +154,9 @@ class HashManager: ObservableObject {
         }
     }
     
-    private func tryICloudIdMatching(identifiers: [String], completion: @escaping ([String]) -> Void) {
+    private func tryICloudIdMatching(identifiers: [String], runID: UUID, completion: @escaping ([String]) -> Void) {
         guard #available(iOS 16, *) else {
+            guard isCurrentRun(runID), !shouldStop else { return }
             completion(identifiers)
             return
         }
@@ -124,6 +164,7 @@ class HashManager: ObservableObject {
         let hasServerCache = DatabaseManager.shared.getServerAssetsCacheCount() > 0
         guard hasServerCache else {
             logInfo("iCloud ID matching skipped: server cache empty, candidates=\(identifiers.count)", category: .hash)
+            guard isCurrentRun(runID), !shouldStop else { return }
             completion(identifiers)
             return
         }
@@ -132,12 +173,17 @@ class HashManager: ObservableObject {
         let matchingStartedAt = Date()
         logInfo("iCloud ID matching started: candidates=\(identifiers.count)", category: .hash)
         
-        Task {
+        matchingTask?.cancel()
+        matchingTask = Task {
             var remainingIdentifiers: [String] = []
             var matchCount = 0
             var identifierToICloudId: [String: String] = [:]
             let totalBatches = (identifiers.count + iCloudIdBatchSize - 1) / iCloudIdBatchSize
             for batchIndex in 0..<totalBatches {
+                guard !Task.isCancelled, self.isCurrentRun(runID) else {
+                    await MainActor.run { self.finishProcessing(runID: runID) }
+                    return
+                }
                 let start = batchIndex * iCloudIdBatchSize
                 let end = min(start + iCloudIdBatchSize, identifiers.count)
                 let batch = Array(identifiers[start..<end])
@@ -155,13 +201,26 @@ class HashManager: ObservableObject {
                 category: .hash
             )
             
+            guard !Task.isCancelled, self.isCurrentRun(runID) else {
+                await MainActor.run { self.finishProcessing(runID: runID) }
+                return
+            }
+
             if identifierToICloudId.isEmpty {
                 await MainActor.run {
+                    guard !Task.isCancelled, self.isCurrentRun(runID), !self.shouldStop else {
+                        self.finishProcessing(runID: runID)
+                        return
+                    }
                     completion(identifiers)
                 }
                 return
             }
             
+            guard !Task.isCancelled, self.isCurrentRun(runID) else {
+                await MainActor.run { self.finishProcessing(runID: runID) }
+                return
+            }
             let iCloudIds = Array(identifierToICloudId.values)
             let checksumMap = DatabaseManager.shared.getChecksumsByICloudIds(iCloudIds)
             logInfo(
@@ -170,14 +229,20 @@ class HashManager: ObservableObject {
             )
             
             for identifier in identifiers {
+                guard !Task.isCancelled, self.isCurrentRun(runID) else {
+                    await MainActor.run { self.finishProcessing(runID: runID) }
+                    return
+                }
                 if let iCloudId = identifierToICloudId[identifier],
                    let checksum = checksumMap[iCloudId] {
+                    guard !Task.isCancelled, self.isCurrentRun(runID) else { return }
                     DatabaseManager.shared.saveMultiResourceHashCache(
                         localIdentifier: identifier,
                         primaryHash: checksum,
                         rawHash: nil,
                         hasRAW: false
                     )
+                    guard !Task.isCancelled, self.isCurrentRun(runID) else { return }
                     
                     DatabaseManager.shared.updateMultiResourceHashCacheServerStatus(
                         localIdentifier: identifier,
@@ -196,6 +261,10 @@ class HashManager: ObservableObject {
             }
             
             await MainActor.run {
+                guard !Task.isCancelled, self.isCurrentRun(runID), !self.shouldStop else {
+                    self.finishProcessing(runID: runID)
+                    return
+                }
                 self.iCloudIdMatchCount = matchCount
                 logInfo("iCloud ID matching finished: matched=\(matchCount), remaining=\(remainingIdentifiers.count), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(matchingStartedAt)))s", category: .hash)
                 completion(remainingIdentifiers)
@@ -203,97 +272,71 @@ class HashManager: ObservableObject {
         }
     }
     
-    /// Process hash calculations in parallel with controlled concurrency
-    private func processHashItemsParallel() {
-        guard !shouldStop else {
-            finishProcessing()
+    /// Processes one PhotoKit resource request at a time. PhotoKit controls chunk
+    /// delivery and may retain buffers until completion, so overlapping requests
+    /// can multiply peak memory for large photos, RAW files, and videos.
+    private func processHashItemsSerially(runID: UUID) {
+        guard isCurrentRun(runID), !shouldStop else {
+            finishProcessing(runID: runID)
             return
         }
-        
+
         guard !processingQueue.isEmpty else {
             statusMessage = "Checking cloud status..."
-            startServerCheck()
+            startServerCheck(runID: runID)
             return
         }
-        
+
         isHashingActive = true
-        
-        // Cancel any existing task
         hashTask?.cancel()
-        
+
         hashTask = Task { [weak self] in
             guard let self = self else { return }
-            
-            // Create a copy of the queue
+
             let identifiersToProcess = self.processingQueue
-            
             await MainActor.run {
-                self.processingQueue.removeAll()
+                self.processingQueue.removeAll(keepingCapacity: false)
             }
-            
-            // Process in parallel with controlled concurrency using TaskGroup
-            await withTaskGroup(of: (String, Bool).self) { group in
-                var activeCount = 0
-                var index = 0
-                
-                while index < identifiersToProcess.count || activeCount > 0 {
-                    // Add tasks up to concurrency limit
-                    while activeCount < self.hashConcurrency && index < identifiersToProcess.count {
-                        guard !self.shouldStop else { break }
-                        
-                        let identifier = identifiersToProcess[index]
-                        index += 1
-                        activeCount += 1
-                        
-                        // Update status to processing
-                        await MainActor.run {
-                            self.syncStatusCache[identifier] = .processing
-                            self.objectWillChange.send()
-                        }
-                        
-                        group.addTask {
-                            await self.processHashForAsset(identifier: identifier)
-                            return (identifier, true)
-                        }
-                    }
-                    
-                    // Wait for one task to complete
-                    if let _ = await group.next() {
-                        activeCount -= 1
-                        
-                        await MainActor.run {
-                            self.processedAssetsCount += 1
-                            self.processingProgress = Double(self.processedAssetsCount) / Double(self.totalAssetsToProcess)
-                            self.statusMessage = "Analyzing photos (\(self.processedAssetsCount)/\(self.totalAssetsToProcess))..."
-                        }
-                    }
-                    
-                    if self.shouldStop {
-                        group.cancelAll()
-                        break
-                    }
+
+            await HashPipelinePolicy.processSerially(identifiersToProcess) { identifier in
+                guard self.isCurrentRun(runID), !self.shouldStop else { return }
+
+                await MainActor.run {
+                    guard self.isCurrentRun(runID) else { return }
+                    self.syncStatusCache[identifier] = .processing
+                    self.objectWillChange.send()
+                }
+
+                await self.processHashForAsset(identifier: identifier, runID: runID)
+
+                await MainActor.run {
+                    guard self.isCurrentRun(runID) else { return }
+                    self.processedAssetsCount += 1
+                    self.processingProgress = Double(self.processedAssetsCount) / Double(self.totalAssetsToProcess)
+                    self.statusMessage = "Analyzing photos (\(self.processedAssetsCount)/\(self.totalAssetsToProcess))..."
                 }
             }
-            
-            // Continue to server check after hashing
+
             await MainActor.run {
-                if !self.shouldStop {
+                if self.isCurrentRun(runID), !self.shouldStop, !Task.isCancelled {
                     self.statusMessage = "Checking cloud status..."
-                    self.startServerCheck()
+                    self.startServerCheck(runID: runID)
                 } else {
-                    self.finishProcessing()
+                    self.finishProcessing(runID: runID)
                 }
             }
         }
     }
     
-    private func processHashForAsset(identifier: String) async {
+    private func processHashForAsset(identifier: String, runID: UUID) async {
         let hashStartedAt = Date()
         logInfo("Hash started: asset=\(identifier)", category: .hash)
         let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil)
+        guard isCurrentRun(runID), !shouldStop else { return }
         
         guard let asset = fetchResult.firstObject else {
             await MainActor.run {
+                guard self.isCurrentRun(runID) else { return }
                 self.syncStatusCache[identifier] = .error
                 self.objectWillChange.send()
             }
@@ -303,6 +346,7 @@ class HashManager: ObservableObject {
         do {
             // Use multi-resource hash to capture both JPEG and RAW hashes
             let result = try await HashService.shared.calculateMultiResourceHash(for: asset)
+            guard isCurrentRun(runID), !shouldStop else { return }
             logInfo(
                 "Hash finished: asset=\(identifier), primaryBytes=\(result.primaryFileSize), rawBytes=\(result.rawFileSize ?? 0), hasRAW=\(result.hasRAW), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(hashStartedAt)))s",
                 category: .hash
@@ -315,8 +359,10 @@ class HashManager: ObservableObject {
                 hasRAW: result.hasRAW,
                 modificationDate: asset.modificationDate
             )
+            guard isCurrentRun(runID) else { return }
             
             await MainActor.run {
+                guard self.isCurrentRun(runID) else { return }
                 self.syncStatusCache[identifier] = .pending
                 self.objectWillChange.send()
             }
@@ -324,15 +370,16 @@ class HashManager: ObservableObject {
         } catch {
             logError("Hash failed: asset=\(identifier), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(hashStartedAt)))s, error=\(error.localizedDescription)", category: .hash)
             await MainActor.run {
+                guard self.isCurrentRun(runID) else { return }
                 self.syncStatusCache[identifier] = .error
                 self.objectWillChange.send()
             }
         }
     }
     
-    private func startServerCheck() {
-        guard !shouldStop else {
-            finishProcessing()
+    private func startServerCheck(runID: UUID) {
+        guard isCurrentRun(runID), !shouldStop else {
+            finishProcessing(runID: runID)
             return
         }
         
@@ -345,28 +392,29 @@ class HashManager: ObservableObject {
             
             // Ensure UI updates happen on main thread
             Task { @MainActor in
+                guard self.isCurrentRun(runID) else { return }
                 if records.isEmpty {
-                    self.finishProcessing()
+                    self.finishProcessing(runID: runID)
                     return
                 }
-                
+
                 self.totalAssetsToProcess = records.count
                 self.processedAssetsCount = 0
                 self.statusMessage = "Checking cloud status (0/\(records.count))..."
-                
-                self.checkMultiResourceHashesAgainstCache(records: records)
+
+                self.checkMultiResourceHashesAgainstCache(records: records, runID: runID)
             }
         }
     }
     
-    private func checkMultiResourceHashesAgainstCache(records: [MultiResourceHashRecord]) {
-        guard !shouldStop else {
-            finishProcessing()
+    private func checkMultiResourceHashesAgainstCache(records: [MultiResourceHashRecord], runID: UUID) {
+        guard isCurrentRun(runID), !shouldStop else {
+            finishProcessing(runID: runID)
             return
         }
         
         guard !records.isEmpty else {
-            finishProcessing()
+            finishProcessing(runID: runID)
             return
         }
         
@@ -375,6 +423,7 @@ class HashManager: ObservableObject {
         
         checkTask = Task { [weak self] in
             guard let self = self else { return }
+            guard self.isCurrentRun(runID), !Task.isCancelled else { return }
             
             // First, filter out deleted photos and collect orphan identifiers
             let allIdentifiers = records.map { $0.assetId }
@@ -398,28 +447,33 @@ class HashManager: ObservableObject {
             }
             
             // Clean up orphan records from database
+            guard self.isCurrentRun(runID), !Task.isCancelled else { return }
+
             if !orphanIdentifiers.isEmpty {
                 logInfo("Cleaning up \(orphanIdentifiers.count) orphan hash cache records for deleted photos", category: .hash)
                 DatabaseManager.shared.batchDeleteHashCacheRecords(localIdentifiers: orphanIdentifiers)
                 
                 // Also remove from memory cache
                 await MainActor.run {
+                    guard self.isCurrentRun(runID) else { return }
                     for identifier in orphanIdentifiers {
                         self.syncStatusCache.removeValue(forKey: identifier)
                     }
                     self.objectWillChange.send()
                 }
+                guard self.isCurrentRun(runID), !Task.isCancelled else { return }
             }
             
             // Update count to only include valid records
             if validRecords.isEmpty {
                 await MainActor.run {
-                    self.finishProcessing()
+                    self.finishProcessing(runID: runID)
                 }
                 return
             }
             
             await MainActor.run {
+                guard self.isCurrentRun(runID) else { return }
                 self.totalAssetsToProcess = validRecords.count
                 self.processedAssetsCount = 0
                 self.statusMessage = "Checking cloud status (0/\(validRecords.count))..."
@@ -445,14 +499,17 @@ class HashManager: ObservableObject {
                         localToCloudId[localId] = cloudId.stringValue
                     }
                 }
+                guard self.isCurrentRun(runID), !Task.isCancelled else { return }
             }
             
             for record in validRecords {
-                guard !self.shouldStop else { break }
+                guard self.isCurrentRun(runID), !self.shouldStop else { break }
                 
                 let localIdentifier = record.assetId
                 
+                guard self.isCurrentRun(runID), !Task.isCancelled else { return }
                 await MainActor.run {
+                    guard self.isCurrentRun(runID) else { return }
                     self.syncStatusCache[localIdentifier] = .checking
                     self.objectWillChange.send()
                 }
@@ -477,20 +534,19 @@ class HashManager: ObservableObject {
                 if primaryOnServer {
                     if let iCloudId = localToCloudId[localIdentifier] {
                         if let immichId = localToImmichId[localIdentifier] {
-                            // From upload records — queue regardless of server cache state
                             await MainActor.run {
+                                guard self.isCurrentRun(runID) else { return }
                                 self.pendingICloudIdUpdates.append((immichId: immichId, iCloudId: iCloudId))
                             }
                         } else if let serverAsset = DatabaseManager.shared.getServerAssetByChecksum(record.primaryHash),
                                   serverAsset.iCloudId != iCloudId,
                                   currentUserId == nil || serverAsset.ownerId == currentUserId {
-                            // From server cache (checksum match) — queue if iCloudId missing or stale, skip partner assets
                             await MainActor.run {
+                                guard self.isCurrentRun(runID) else { return }
                                 self.pendingICloudIdUpdates.append((immichId: serverAsset.immichId, iCloudId: iCloudId))
                             }
                         }
                     } else {
-                        // Asset is on server but iCloud ID is incomplete or unavailable — log for diagnosis
                         logInfo("Asset \(localIdentifier) on server but no valid iCloud ID (iCloud sync incomplete?)", category: .hash)
                     }
                 }
@@ -503,6 +559,7 @@ class HashManager: ObservableObject {
                         rawOnServer = DatabaseManager.shared.isAssetOnServer(checksum: rawHash)
                     }
                 }
+                guard self.isCurrentRun(runID), !Task.isCancelled else { return }
                 
                 // Update database with multi-resource status
                 DatabaseManager.shared.updateMultiResourceHashCacheServerStatus(
@@ -520,16 +577,17 @@ class HashManager: ObservableObject {
                 } else {
                     isFullyUploaded = primaryOnServer
                 }
+                guard self.isCurrentRun(runID), !Task.isCancelled else { return }
                 
                 await MainActor.run {
+                    guard self.isCurrentRun(runID) else { return }
                     self.processedAssetsCount += 1
                     self.processingProgress = Double(self.processedAssetsCount) / Double(self.totalAssetsToProcess)
                     self.statusMessage = "Checking cloud status (\(self.processedAssetsCount)/\(self.totalAssetsToProcess))..."
-                    
+
                     if isFullyUploaded {
                         self.syncStatusCache[localIdentifier] = .uploaded
                     } else {
-                        // Not uploaded - show as not uploaded regardless of server cache
                         self.syncStatusCache[localIdentifier] = .notUploaded
                     }
                     self.objectWillChange.send()
@@ -537,26 +595,37 @@ class HashManager: ObservableObject {
             }
             
             await MainActor.run {
-                self.finishProcessing()
+                self.finishProcessing(runID: runID)
             }
         }
     }
     
-    private func finishProcessing() {
+    private func finishProcessing(runID: UUID) {
+        guard isCurrentRun(runID) else { return }
+        runState.invalidate()
         isProcessing = false
         isHashingActive = false
         isCheckingActive = false
         statusMessage = ""
         processingProgress = 1.0
-        
+
         loadCachedStatus()
     }
     
     func stopProcessing() {
+        runState.invalidate()
         shouldStop = true
-        statusMessage = "Stopping..."
+        isProcessing = false
+        isHashingActive = false
+        isCheckingActive = false
+        statusMessage = ""
         hashTask?.cancel()
         checkTask?.cancel()
+        matchingTask?.cancel()
+    }
+
+    private func isCurrentRun(_ runID: UUID) -> Bool {
+        runState.owns(runID)
     }
     
     func getSyncStatus(for localIdentifier: String) -> PhotoSyncStatus {

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -52,6 +52,7 @@ class HashManager: ObservableObject {
     private var processingQueue: [String] = []
     private var isHashingActive = false
     private var isCheckingActive = false
+    private var isStopping = false
     
     private let checkQueue = DispatchQueue(label: "com.fawenyo.yaiiu.check", qos: .utility)
     
@@ -107,7 +108,7 @@ class HashManager: ObservableObject {
     }
 
     func startBackgroundProcessing(identifiers: [String]) {
-        guard !isHashingActive && !isCheckingActive else { return }
+        guard !isStopping && !isHashingActive && !isCheckingActive else { return }
 
         let runID = runState.begin()
         shouldStop = false
@@ -606,6 +607,7 @@ class HashManager: ObservableObject {
         isProcessing = false
         isHashingActive = false
         isCheckingActive = false
+        isStopping = false
         statusMessage = ""
         processingProgress = 1.0
 
@@ -613,15 +615,28 @@ class HashManager: ObservableObject {
     }
     
     func stopProcessing() {
+        guard !isStopping else { return }
+
         runState.invalidate()
         shouldStop = true
+        isStopping = true
         isProcessing = false
-        isHashingActive = false
-        isCheckingActive = false
         statusMessage = ""
-        hashTask?.cancel()
-        checkTask?.cancel()
-        matchingTask?.cancel()
+
+        let tasks = [hashTask, checkTask, matchingTask].compactMap { $0 }
+        tasks.forEach { $0.cancel() }
+
+        Task { @MainActor [weak self] in
+            for task in tasks {
+                await task.value
+            }
+
+            guard let self, self.isStopping else { return }
+            await self.refreshStatusCacheAsync()
+            self.isHashingActive = false
+            self.isCheckingActive = false
+            self.isStopping = false
+        }
     }
 
     private func isCurrentRun(_ runID: UUID) -> Bool {

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -25,6 +25,15 @@ enum HashPipelinePolicy {
             return runID
         }
 
+        func beginIfIdle() -> UUID? {
+            let runID = UUID()
+            lock.lock()
+            defer { lock.unlock() }
+            guard currentRunID == nil else { return nil }
+            currentRunID = runID
+            return runID
+        }
+
         func invalidate() {
             lock.lock()
             currentRunID = nil
@@ -109,15 +118,22 @@ class HashManager: ObservableObject {
     }
     
     func startBackgroundProcessing(assets: [PHAsset]) {
-        // Invalidate modified assets before the normal refresh pipeline
-        DatabaseManager.shared.resetCacheForModifiedAssets(assets: assets)
-        startBackgroundProcessing(identifiers: assets.map { $0.localIdentifier })
+        startBackgroundProcessing(
+            identifiers: assets.map { $0.localIdentifier },
+            assetsToInvalidate: assets
+        )
     }
 
     func startBackgroundProcessing(identifiers: [String]) {
-        guard !isStopping && !isHashingActive && !isCheckingActive else { return }
+        startBackgroundProcessing(identifiers: identifiers, assetsToInvalidate: nil)
+    }
 
-        let runID = runState.begin()
+    private func startBackgroundProcessing(identifiers: [String], assetsToInvalidate: [PHAsset]?) {
+        guard !isStopping && !isHashingActive && !isCheckingActive else { return }
+        guard let runID = runState.beginIfIdle() else { return }
+        if let assetsToInvalidate {
+            DatabaseManager.shared.resetCacheForModifiedAssets(assets: assetsToInvalidate)
+        }
         shouldStop = false
         isProcessing = true
         iCloudIdMatchCount = 0

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -13,37 +13,65 @@ enum HashPipelinePolicy {
         }
     }
 
-    final class RunState: @unchecked Sendable {
-        private let lock = NSLock()
-        private var currentRunID: UUID?
+    static func admitIfIdle(
+        using state: RunState,
+        performSideEffects: (UUID) -> Void
+    ) -> UUID? {
+        guard let runID = state.beginIfIdle() else { return nil }
+        performSideEffects(runID)
+        return runID
+    }
 
-        func begin() -> UUID {
-            let runID = UUID()
-            lock.lock()
-            currentRunID = runID
-            lock.unlock()
-            return runID
+    final class RunState: @unchecked Sendable {
+        private enum Phase {
+            case idle
+            case running(UUID)
+            case stopping
         }
+
+        private let lock = NSLock()
+        private var phase = Phase.idle
 
         func beginIfIdle() -> UUID? {
             let runID = UUID()
             lock.lock()
             defer { lock.unlock() }
-            guard currentRunID == nil else { return nil }
-            currentRunID = runID
+            guard case .idle = phase else { return nil }
+            phase = .running(runID)
             return runID
         }
 
-        func invalidate() {
+        func finish(_ runID: UUID) -> Bool {
             lock.lock()
-            currentRunID = nil
+            defer { lock.unlock() }
+            guard case .running(runID) = phase else { return false }
+            phase = .idle
+            return true
+        }
+
+        func beginStopping() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            guard case .stopping = phase else {
+                phase = .stopping
+                return true
+            }
+            return false
+        }
+
+        func finishStopping() {
+            lock.lock()
+            if case .stopping = phase {
+                phase = .idle
+            }
             lock.unlock()
         }
 
         func owns(_ runID: UUID) -> Bool {
             lock.lock()
             defer { lock.unlock() }
-            return currentRunID == runID
+            guard case .running(runID) = phase else { return false }
+            return true
         }
     }
 }
@@ -117,6 +145,7 @@ class HashManager: ObservableObject {
         }
     }
     
+    @MainActor
     func startBackgroundProcessing(assets: [PHAsset]) {
         startBackgroundProcessing(
             identifiers: assets.map { $0.localIdentifier },
@@ -124,16 +153,27 @@ class HashManager: ObservableObject {
         )
     }
 
+    @MainActor
     func startBackgroundProcessing(identifiers: [String]) {
         startBackgroundProcessing(identifiers: identifiers, assetsToInvalidate: nil)
     }
 
-    private func startBackgroundProcessing(identifiers: [String], assetsToInvalidate: [PHAsset]?) {
+    @MainActor
+    private func startBackgroundProcessing(
+        identifiers: [String],
+        assetsToInvalidate: [PHAsset]?,
+        shouldClearCache: Bool = false
+    ) {
         guard !isStopping && !isHashingActive && !isCheckingActive else { return }
-        guard let runID = runState.beginIfIdle() else { return }
-        if let assetsToInvalidate {
-            DatabaseManager.shared.resetCacheForModifiedAssets(assets: assetsToInvalidate)
-        }
+        guard let runID = HashPipelinePolicy.admitIfIdle(using: runState, performSideEffects: { _ in
+            if shouldClearCache {
+                DatabaseManager.shared.clearHashCache()
+                syncStatusCache.removeAll()
+            }
+            if let assetsToInvalidate {
+                DatabaseManager.shared.resetCacheForModifiedAssets(assets: assetsToInvalidate)
+            }
+        }) else { return }
         shouldStop = false
         isProcessing = true
         iCloudIdMatchCount = 0
@@ -625,8 +665,7 @@ class HashManager: ObservableObject {
     }
     
     private func finishProcessing(runID: UUID) {
-        guard isCurrentRun(runID) else { return }
-        runState.invalidate()
+        guard runState.finish(runID) else { return }
         isProcessing = false
         isHashingActive = false
         isCheckingActive = false
@@ -637,10 +676,10 @@ class HashManager: ObservableObject {
         loadCachedStatus()
     }
     
+    @MainActor
     func stopProcessing() {
-        guard !isStopping else { return }
+        guard runState.beginStopping() else { return }
 
-        runState.invalidate()
         shouldStop = true
         isStopping = true
         statusMessage = "Stopping..."
@@ -659,6 +698,7 @@ class HashManager: ObservableObject {
             self.isHashingActive = false
             self.isCheckingActive = false
             self.isStopping = false
+            self.runState.finishStopping()
             self.statusMessage = ""
         }
     }
@@ -689,10 +729,12 @@ class HashManager: ObservableObject {
         }
     }
     
+    @MainActor
     func forceReprocess(assets: [PHAsset]) {
-        DatabaseManager.shared.clearHashCache()
-        syncStatusCache.removeAll()
-        
-        startBackgroundProcessing(assets: assets)
+        startBackgroundProcessing(
+            identifiers: assets.map { $0.localIdentifier },
+            assetsToInvalidate: assets,
+            shouldClearCache: true
+        )
     }
 }

--- a/YAIIU/YAIIU/Services/HashService.swift
+++ b/YAIIU/YAIIU/Services/HashService.swift
@@ -51,6 +51,92 @@ class StreamingSHA1 {
     }
 }
 
+private final class CancellableRequestState<RequestID, Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<Value, Error>?
+    private var requestID: RequestID?
+    private var cancelRequest: ((RequestID) -> Void)?
+    private var isCancelled = false
+    private var isCompleted = false
+
+    func installContinuation(_ continuation: CheckedContinuation<Value, Error>) {
+        lock.lock()
+        self.continuation = continuation
+        lock.unlock()
+    }
+
+    func installRequest(_ requestID: RequestID, cancel: @escaping (RequestID) -> Void) {
+        lock.lock()
+        guard !isCompleted else {
+            lock.unlock()
+            return
+        }
+        self.requestID = requestID
+        cancelRequest = cancel
+        let shouldCancel = isCancelled
+        lock.unlock()
+
+        if shouldCancel {
+            cancel(requestID)
+        }
+    }
+
+    func cancel() {
+        lock.lock()
+        guard !isCompleted, !isCancelled else {
+            lock.unlock()
+            return
+        }
+        isCancelled = true
+        let requestID = self.requestID
+        let cancelRequest = self.cancelRequest
+        lock.unlock()
+
+        if let requestID, let cancelRequest {
+            cancelRequest(requestID)
+        }
+    }
+
+    func complete(_ result: Result<Value, Error>) {
+        lock.lock()
+        guard !isCompleted, let continuation else {
+            lock.unlock()
+            return
+        }
+        isCompleted = true
+        self.continuation = nil
+        requestID = nil
+        cancelRequest = nil
+        let isCancelled = self.isCancelled
+        lock.unlock()
+
+        if isCancelled {
+            continuation.resume(throwing: CancellationError())
+        } else {
+            continuation.resume(with: result)
+        }
+    }
+}
+
+func withCancellableRequest<RequestID, Value>(
+    start: (@escaping (Result<Value, Error>) -> Void) -> RequestID,
+    cancel: @escaping (RequestID) -> Void
+) async throws -> Value {
+    let state = CancellableRequestState<RequestID, Value>()
+
+    return try await withTaskCancellationHandler {
+        try await withCheckedThrowingContinuation { continuation in
+            state.installContinuation(continuation)
+            let requestID = start { result in
+                state.complete(result)
+            }
+            state.installRequest(requestID, cancel: cancel)
+        }
+    } onCancel: {
+        state.cancel()
+    }
+}
+
 class HashService {
     static let shared = HashService()
     
@@ -175,34 +261,37 @@ class HashService {
     }
     
     private func calculateSHA1Streaming(for resource: PHAssetResource) async throws -> (String, Int) {
-        return try await withCheckedThrowingContinuation { continuation in
-            let sha1 = StreamingSHA1()
-            let options = PHAssetResourceRequestOptions()
-            options.isNetworkAccessAllowed = true
-            let requestStartedAt = Date()
-            logInfo(
-                "Resource data request started: type=\(String(describing: resource.type)), networkAllowed=true",
-                category: .hash
-            )
-            
-            PHAssetResourceManager.default().requestData(for: resource, options: options) { chunk in
+        let manager = PHAssetResourceManager.default()
+        let sha1 = StreamingSHA1()
+        let options = PHAssetResourceRequestOptions()
+        options.isNetworkAccessAllowed = true
+        let requestStartedAt = Date()
+        logInfo(
+            "Resource data request started: type=\(String(describing: resource.type)), networkAllowed=true",
+            category: .hash
+        )
+
+        return try await withCancellableRequest { completion in
+            manager.requestData(for: resource, options: options) { chunk in
                 sha1.update(data: chunk)
             } completionHandler: { error in
-                if let error = error {
+                if let error {
                     logError(
                         "Resource data request failed: type=\(String(describing: resource.type)), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(requestStartedAt)))s, error=\(error.localizedDescription)",
                         category: .hash
                     )
-                    continuation.resume(throwing: error)
+                    completion(.failure(error))
                 } else {
                     let hash = sha1.finalize()
                     logInfo(
                         "Resource data request finished: type=\(String(describing: resource.type)), bytes=\(sha1.totalSize), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(requestStartedAt)))s",
                         category: .hash
                     )
-                    continuation.resume(returning: (hash, sha1.totalSize))
+                    completion(.success((hash, sha1.totalSize)))
                 }
             }
+        } cancel: { requestID in
+            manager.cancelDataRequest(requestID)
         }
     }
 }

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -69,6 +69,44 @@ final class HashPipelinePolicyTests: XCTestCase {
         XCTAssertFalse(state.owns(runID))
     }
 
+    func testRunStateRejectsOverlappingRunUntilInvalidated() {
+        let state = HashPipelinePolicy.RunState()
+
+        let firstRunID = state.beginIfIdle()
+        let overlappingRunID = state.beginIfIdle()
+
+        XCTAssertNotNil(firstRunID)
+        XCTAssertNil(overlappingRunID)
+
+        state.invalidate()
+
+        XCTAssertNotNil(state.beginIfIdle())
+    }
+
+    func testRunStateAllowsExactlyOneConcurrentStart() async {
+        let state = HashPipelinePolicy.RunState()
+        let winners = await withTaskGroup(of: UUID?.self, returning: [UUID].self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    state.beginIfIdle()
+                }
+            }
+
+            var runIDs: [UUID] = []
+            for await runID in group {
+                if let runID {
+                    runIDs.append(runID)
+                }
+            }
+            return runIDs
+        }
+
+        guard let winner = winners.only else {
+            return XCTFail("Expected exactly one run to start, got \(winners.count)")
+        }
+        XCTAssertTrue(state.owns(winner))
+    }
+
     func testRunStateIsSafeAcrossConcurrentAccess() async {
         let state = HashPipelinePolicy.RunState()
 
@@ -145,5 +183,11 @@ private final class RequestCompletionBox<Value>: @unchecked Sendable {
         let handler = self.handler
         lock.unlock()
         handler?(result)
+    }
+}
+
+private extension Collection {
+    var only: Element? {
+        count == 1 ? first : nil
     }
 }

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -51,22 +51,107 @@ final class HashPipelinePolicyTests: XCTestCase {
         await fulfillment(of: [startedSecondOperation], timeout: 0.1)
     }
 
-    func testOldRunCannotOwnStateAfterRestart() {
-        var state = HashPipelinePolicy.RunState()
-        let oldRunID = state.begin()
-        let newRunID = state.begin()
+    func testFinishedRunCannotOwnStateAfterRestart() {
+        let state = HashPipelinePolicy.RunState()
+        let oldRunID = state.beginIfIdle()
 
+        guard let oldRunID else {
+            return XCTFail("Expected the first run to start")
+        }
+        XCTAssertTrue(state.finish(oldRunID))
+
+        let newRunID = state.beginIfIdle()
+
+        guard let newRunID else {
+            return XCTFail("Expected the second run to start")
+        }
         XCTAssertFalse(state.owns(oldRunID))
         XCTAssertTrue(state.owns(newRunID))
     }
 
-    func testInvalidationPreventsStoppedRunFromOwningState() {
-        var state = HashPipelinePolicy.RunState()
-        let runID = state.begin()
+    func testFinishingRunPreventsItFromOwningState() {
+        let state = HashPipelinePolicy.RunState()
+        let runID = state.beginIfIdle()
 
-        state.invalidate()
+        guard let runID else {
+            return XCTFail("Expected the run to start")
+        }
+        XCTAssertTrue(state.finish(runID))
 
         XCTAssertFalse(state.owns(runID))
+    }
+
+    func testStaleFinishCannotReleaseCurrentRun() {
+        let state = HashPipelinePolicy.RunState()
+        guard let oldRunID = state.beginIfIdle() else {
+            return XCTFail("Expected the old run to start")
+        }
+        XCTAssertTrue(state.finish(oldRunID))
+        guard let currentRunID = state.beginIfIdle() else {
+            return XCTFail("Expected the current run to start")
+        }
+
+        XCTAssertFalse(state.finish(oldRunID))
+        XCTAssertTrue(state.owns(currentRunID))
+    }
+
+    func testStaleFinishCannotReleaseStoppingPhase() {
+        let state = HashPipelinePolicy.RunState()
+        guard let runID = state.beginIfIdle() else {
+            return XCTFail("Expected the run to start")
+        }
+        XCTAssertTrue(state.beginStopping())
+
+        XCTAssertFalse(state.finish(runID))
+        XCTAssertNil(state.beginIfIdle())
+
+        state.finishStopping()
+        XCTAssertNotNil(state.beginIfIdle())
+    }
+
+    func testRejectedAdmissionDoesNotRunSideEffects() {
+        let state = HashPipelinePolicy.RunState()
+        XCTAssertNotNil(state.beginIfIdle())
+        var sideEffectCount = 0
+
+        let rejectedRunID = HashPipelinePolicy.admitIfIdle(using: state) { _ in
+            sideEffectCount += 1
+        }
+
+        XCTAssertNil(rejectedRunID)
+        XCTAssertEqual(sideEffectCount, 0)
+    }
+
+    func testSuccessfulAdmissionRunsSideEffectsOnce() {
+        let state = HashPipelinePolicy.RunState()
+        var sideEffectCount = 0
+
+        let runID = HashPipelinePolicy.admitIfIdle(using: state) { admittedRunID in
+            XCTAssertTrue(state.owns(admittedRunID))
+            sideEffectCount += 1
+        }
+
+        XCTAssertNotNil(runID)
+        XCTAssertEqual(sideEffectCount, 1)
+    }
+
+    func testStoppingAdmissionRejectsStartWithoutSideEffects() {
+        let state = HashPipelinePolicy.RunState()
+        XCTAssertTrue(state.beginStopping())
+        var sideEffectCount = 0
+
+        let rejectedRunID = HashPipelinePolicy.admitIfIdle(using: state) { _ in
+            sideEffectCount += 1
+        }
+
+        XCTAssertNil(rejectedRunID)
+        XCTAssertEqual(sideEffectCount, 0)
+
+        state.finishStopping()
+        XCTAssertNotNil(HashPipelinePolicy.admitIfIdle(using: state) { _ in
+            sideEffectCount += 1
+        })
+        XCTAssertEqual(sideEffectCount, 1)
     }
 
     func testRunStateRejectsOverlappingRunUntilInvalidated() {
@@ -78,7 +163,20 @@ final class HashPipelinePolicyTests: XCTestCase {
         XCTAssertNotNil(firstRunID)
         XCTAssertNil(overlappingRunID)
 
-        state.invalidate()
+        XCTAssertTrue(state.finish(firstRunID!))
+
+        XCTAssertNotNil(state.beginIfIdle())
+    }
+
+    func testRunStateRejectsStartsWhileStopping() {
+        let state = HashPipelinePolicy.RunState()
+        let runID = state.beginIfIdle()
+
+        XCTAssertNotNil(runID)
+        XCTAssertTrue(state.beginStopping())
+        XCTAssertNil(state.beginIfIdle())
+
+        state.finishStopping()
 
         XCTAssertNotNil(state.beginIfIdle())
     }
@@ -113,18 +211,25 @@ final class HashPipelinePolicyTests: XCTestCase {
         await withTaskGroup(of: Void.self) { group in
             for _ in 0..<100 {
                 group.addTask {
-                    let runID = state.begin()
-                    _ = state.owns(runID)
+                    if let runID = state.beginIfIdle() {
+                        _ = state.owns(runID)
+                        _ = state.finish(runID)
+                    }
                 }
                 group.addTask {
-                    state.invalidate()
+                    if state.beginStopping() {
+                        state.finishStopping()
+                    }
                 }
             }
         }
 
-        let finalRunID = state.begin()
+        let finalRunID = state.beginIfIdle()
+        guard let finalRunID else {
+            return XCTFail("Expected a run after concurrent access")
+        }
         XCTAssertTrue(state.owns(finalRunID))
-        state.invalidate()
+        XCTAssertTrue(state.finish(finalRunID))
         XCTAssertFalse(state.owns(finalRunID))
     }
 

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import YAIIU
+
+final class HashPipelinePolicyTests: XCTestCase {
+    actor ConcurrencyProbe {
+        private(set) var activeCount = 0
+        private(set) var maximumActiveCount = 0
+
+        func begin() {
+            activeCount += 1
+            maximumActiveCount = max(maximumActiveCount, activeCount)
+        }
+
+        func end() {
+            activeCount -= 1
+        }
+    }
+
+    func testProcessesHashOperationsSerially() async {
+        let probe = ConcurrencyProbe()
+
+        await HashPipelinePolicy.processSerially([1, 2, 3]) { _ in
+            await probe.begin()
+            try? await Task.sleep(nanoseconds: 10_000_000)
+            await probe.end()
+        }
+
+        let maximumActiveCount = await probe.maximumActiveCount
+        XCTAssertEqual(maximumActiveCount, 1)
+    }
+
+    func testCancellationStopsBeforeNextOperation() async {
+        let firstOperationStarted = expectation(description: "first operation starts")
+        let startedSecondOperation = expectation(description: "second operation starts")
+        startedSecondOperation.isInverted = true
+
+        let task = Task {
+            await HashPipelinePolicy.processSerially([1, 2]) { value in
+                if value == 1 {
+                    firstOperationStarted.fulfill()
+                    try? await Task.sleep(nanoseconds: 1_000_000_000)
+                } else {
+                    startedSecondOperation.fulfill()
+                }
+            }
+        }
+
+        await fulfillment(of: [firstOperationStarted], timeout: 1.0)
+        task.cancel()
+        await task.value
+        await fulfillment(of: [startedSecondOperation], timeout: 0.1)
+    }
+
+    func testOldRunCannotOwnStateAfterRestart() {
+        var state = HashPipelinePolicy.RunState()
+        let oldRunID = state.begin()
+        let newRunID = state.begin()
+
+        XCTAssertFalse(state.owns(oldRunID))
+        XCTAssertTrue(state.owns(newRunID))
+    }
+
+    func testInvalidationPreventsStoppedRunFromOwningState() {
+        var state = HashPipelinePolicy.RunState()
+        let runID = state.begin()
+
+        state.invalidate()
+
+        XCTAssertFalse(state.owns(runID))
+    }
+}

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -68,4 +68,61 @@ final class HashPipelinePolicyTests: XCTestCase {
 
         XCTAssertFalse(state.owns(runID))
     }
+
+    func testCancellationCancelsRequestAndWaitsForCompletion() async {
+        let requestStarted = expectation(description: "request starts")
+        let cancellationForwarded = expectation(description: "cancellation reaches request")
+        let taskFinished = expectation(description: "task finishes")
+        taskFinished.isInverted = true
+        let completion = RequestCompletionBox<Int>()
+
+        let task = Task {
+            defer { taskFinished.fulfill() }
+            return try await withCancellableRequest(
+                start: { handler in
+                    completion.store(handler)
+                    requestStarted.fulfill()
+                    return 42
+                },
+                cancel: { requestID in
+                    XCTAssertEqual(requestID, 42)
+                    cancellationForwarded.fulfill()
+                }
+            )
+        }
+
+        await fulfillment(of: [requestStarted], timeout: 1.0)
+        task.cancel()
+        await fulfillment(of: [cancellationForwarded], timeout: 1.0)
+        await fulfillment(of: [taskFinished], timeout: 0.1)
+
+        completion.finish(.success(1))
+
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Expected after the underlying request reports completion.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+    }
+}
+
+private final class RequestCompletionBox<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var handler: ((Result<Value, Error>) -> Void)?
+
+    func store(_ handler: @escaping (Result<Value, Error>) -> Void) {
+        lock.lock()
+        self.handler = handler
+        lock.unlock()
+    }
+
+    func finish(_ result: Result<Value, Error>) {
+        lock.lock()
+        let handler = self.handler
+        lock.unlock()
+        handler?(result)
+    }
 }

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -69,6 +69,27 @@ final class HashPipelinePolicyTests: XCTestCase {
         XCTAssertFalse(state.owns(runID))
     }
 
+    func testRunStateIsSafeAcrossConcurrentAccess() async {
+        let state = HashPipelinePolicy.RunState()
+
+        await withTaskGroup(of: Void.self) { group in
+            for _ in 0..<100 {
+                group.addTask {
+                    let runID = state.begin()
+                    _ = state.owns(runID)
+                }
+                group.addTask {
+                    state.invalidate()
+                }
+            }
+        }
+
+        let finalRunID = state.begin()
+        XCTAssertTrue(state.owns(finalRunID))
+        state.invalidate()
+        XCTAssertFalse(state.owns(finalRunID))
+    }
+
     func testCancellationCancelsRequestAndWaitsForCompletion() async {
         let requestStarted = expectation(description: "request starts")
         let cancellationForwarded = expectation(description: "cancellation reaches request")


### PR DESCRIPTION
### **User description**
## Description

This PR is to reduce memory usage when hashing assets


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Serializes PhotoKit hashing to reduce peak memory

- Cancels resource requests and waits for completion

- Synchronizes pipeline runs against stale callbacks

- Adds concurrency, lifecycle, cancellation coverage


___

### Diagram Walkthrough


```mermaid
flowchart LR
  policy["HashPipelinePolicy"]
  manager["HashManager"]
  service["HashService"]
  request["Cancellable PhotoKit request"]
  tests["HashPipelinePolicyTests"]
  policy -- "serializes operations" --> manager
  manager -- "runs one hash at a time" --> service
  service -- "cancels on task cancellation" --> request
  tests -- "verifies lifecycle and cancellation" --> policy
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HashManager.swift</strong><dd><code>Serializes Hashing And Protects Run Lifecycle</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/HashManager.swift

<ul><li>Serializes per-asset hashing to reduce memory pressure<br> <li> Adds UUID run ownership and synchronized lifecycle state<br> <li> Cancels and awaits active pipeline tasks<br> <li> Guards callbacks and cache updates against stale runs</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/74/files#diff-48c8762133ba95f35c0c78548b2173756c771713afa5120ae70b051c752c1160">+253/-103</a></td>

</tr>
</table></td></tr><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HashService.swift</strong><dd><code>Adds Cancellable PhotoKit Resource Hash Requests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/HashService.swift

<ul><li>Adds cancellable continuation handling for PhotoKit requests<br> <li> Forwards task cancellation to <code>cancelDataRequest</code><br> <li> Prevents double completion during cancellation races</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/74/files#diff-5e8f0013a451135775698941b8f1f85973800786de8f7b6058c2d81c8c3cd6eb">+103/-14</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>HashPipelinePolicyTests.swift</strong><dd><code>Tests Hash Pipeline Serialization And Cancellation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIUTests/HashPipelinePolicyTests.swift

<ul><li>Verifies serial operation and cancellation behavior<br> <li> Covers stale run ownership and finish protection<br> <li> Tests atomic admission across concurrent starts<br> <li> Confirms cancellation forwarding waits for completion</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/74/files#diff-98e4b2a476d2500df42da04cb9627969a53dc3c5bff567bda9c6c391f4ef669e">+298/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>project.pbxproj</strong><dd><code>Registers Hash Pipeline Tests In Xcode Project</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU.xcodeproj/project.pbxproj

<ul><li>Registers the new policy test file<br> <li> Adds test target source and group references</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/74/files#diff-a9ccf84fe91bc6f70ac074cf8cb838a46a4ff6cc8ee6e396d1fd9569e82e0be5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

