### PR TITLE
Fix: OOM during hashing; pipeline downloads ahead of hashing

### DIFF
--- a/YAIIU/YAIIU.xcodeproj/project.pbxproj
+++ b/YAIIU/YAIIU.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		2A0000170000000000000001 /* PhotoAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0000180000000000000001 /* PhotoAsset.swift */; };
 		2A0000190000000000000001 /* UploadProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A00001A0000000000000001 /* UploadProgressView.swift */; };
 		2A00002E0000000000000001 /* HashService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A00002F0000000000000001 /* HashService.swift */; };
+		2A0000A10000000000000001 /* ResourceFileAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0000A20000000000000001 /* ResourceFileAccess.swift */; };
 		2A0000300000000000000001 /* HashManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0000310000000000000001 /* HashManager.swift */; };
 		2A0000320000000000000001 /* ImmichSQLiteImporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0000330000000000000001 /* ImmichSQLiteImporter.swift */; };
 		2A0000340000000000000001 /* ImportDatabaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0000350000000000000001 /* ImportDatabaseView.swift */; };
@@ -114,6 +115,7 @@
 		2A00001B0000000000000001 /* YAIIU.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = YAIIU.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2A00001C0000000000000001 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2A00002F0000000000000001 /* HashService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashService.swift; sourceTree = "<group>"; };
+		2A0000A20000000000000001 /* ResourceFileAccess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResourceFileAccess.swift; sourceTree = "<group>"; };
 		2A0000310000000000000001 /* HashManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HashManager.swift; sourceTree = "<group>"; };
 		2A0000330000000000000001 /* ImmichSQLiteImporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImmichSQLiteImporter.swift; sourceTree = "<group>"; };
 		2A0000350000000000000001 /* ImportDatabaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImportDatabaseView.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				2A0000140000000000000001 /* SettingsManager.swift */,
 				2A0000160000000000000001 /* UploadManager.swift */,
 				2A00002F0000000000000001 /* HashService.swift */,
+				2A0000A20000000000000001 /* ResourceFileAccess.swift */,
 				2A0000310000000000000001 /* HashManager.swift */,
 				2A0000430000000000000001 /* LogService.swift */,
 				2A0000450000000000000001 /* ThumbnailCache.swift */,
@@ -549,6 +552,7 @@
 				2A0000190000000000000001 /* UploadProgressView.swift in Sources */,
 				2A00002E0000000000000001 /* HashService.swift in Sources */,
 				2A0000300000000000000001 /* HashManager.swift in Sources */,
+				2A0000A10000000000000001 /* ResourceFileAccess.swift in Sources */,
 				BC7F35272EFED8F200747537 /* BackgroundUploadDatabase.swift in Sources */,
 				BC7F35282EFED8F200747537 /* SharedSettings.swift in Sources */,
                 BU0000010000000000000001 /* BackgroundUploadPolicy.swift in Sources */,

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -265,6 +265,7 @@ class HashManager: ObservableObject {
     /// independently of how many downloads are in flight; a resource larger
     /// than the whole budget is admitted alone (see ResourceBudget).
     private static let diskBudgetBytes: Int64 = 1_500 * 1024 * 1024
+    private static let hashDiskBudget = ResourceBudget(limit: diskBudgetBytes)
     /// Assets hashed concurrently. Hashing reads with a fixed buffer, so this
     /// only caps CPU/IO overlap, not memory.
     private static let hashConcurrency = 3
@@ -530,7 +531,7 @@ class HashManager: ObservableObject {
                 self.processingQueue.removeAll(keepingCapacity: false)
             }
 
-            let budget = ResourceBudget(limit: Self.diskBudgetBytes)
+            let budget = Self.hashDiskBudget
             let hashGate = ResourceBudget(limit: Int64(Self.hashConcurrency))
             let registry = PreparedWorkRegistry()
             var streamContinuation: AsyncStream<PreparedHashWork>.Continuation!
@@ -677,12 +678,13 @@ class HashManager: ObservableObject {
         }
 
         let actual = files.actualBytes
-        budget.adjust(from: estimate, to: actual)
+        let charged = max(estimate, actual)
+        budget.adjust(from: estimate, to: charged)
 
         // Hand the files to the consumer; the registry entry lets the run sweep
         // them if the cancelled stream discards the buffered handoff. The
         // reservation stays charged until the consumer completes the work.
-        let work = PreparedHashWork(files: files, reservedBytes: actual, budget: budget)
+        let work = PreparedHashWork(files: files, reservedBytes: charged, budget: budget)
         registry.record(work)
         work.onCompletion { [weak registry, weak work] in
             guard let work else { return }
@@ -722,6 +724,7 @@ class HashManager: ObservableObject {
         defer { work.complete() }
         let identifier = files.plan.localIdentifier
         let hashStartedAt = Date()
+        guard isCurrentRun(runID), !shouldStop, !Task.isCancelled else { return }
 
         do {
             let result = try await HashService.shared.hash(files)
@@ -1002,24 +1005,20 @@ class HashManager: ObservableObject {
 
         shouldStop = true
         isStopping = true
-        statusMessage = "Stopping..."
-
         let tasks = [hashTask, checkTask, matchingTask].compactMap { $0 }
         tasks.forEach { $0.cancel() }
 
+        // PhotoKit writes cannot be cancelled. Let their detached run cleanup
+        // finish later while immediately retiring this run from the UI. The
+        // shared disk budget keeps a replacement run behind those writes.
+        isProcessing = false
+        isHashingActive = false
+        isCheckingActive = false
+        isStopping = false
+        runState.finishStopping()
+        statusMessage = ""
         Task { @MainActor [weak self] in
-            for task in tasks {
-                await task.value
-            }
-
-            guard let self, self.isStopping else { return }
-            await self.refreshStatusCacheAsync()
-            self.isProcessing = false
-            self.isHashingActive = false
-            self.isCheckingActive = false
-            self.isStopping = false
-            self.runState.finishStopping()
-            self.statusMessage = ""
+            await self?.refreshStatusCacheAsync()
         }
     }
 

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -3,13 +3,37 @@ import Photos
 import Combine
 
 enum HashPipelinePolicy {
-    static func processSerially<Element>(
+    /// Runs operations with at most `limit` in flight. PhotoKit file requests
+    /// keep only a fixed read buffer in-process, so a small fan-out pipelines
+    /// iCloud downloads and hashing without meaningful memory growth.
+    static func processConcurrently<Element: Sendable>(
         _ elements: [Element],
-        operation: (Element) async -> Void
+        limit: Int,
+        operation: @escaping @Sendable (Element) async -> Void
     ) async {
-        for element in elements {
-            guard !Task.isCancelled else { break }
-            await operation(element)
+        await withTaskGroup(of: Void.self) { group in
+            let limit = max(1, Swift.min(limit, elements.count))
+            var index = 0
+            var inFlight = 0
+
+            func addNext() {
+                guard index < elements.count, inFlight < limit else { return }
+                let element = elements[index]
+                index += 1
+                inFlight += 1
+                group.addTask {
+                    guard !Task.isCancelled else { return }
+                    await operation(element)
+                }
+            }
+
+            while inFlight < limit, index < elements.count { addNext() }
+
+            while inFlight > 0 {
+                _ = await group.next()
+                inFlight -= 1
+                addNext()
+            }
         }
     }
 
@@ -102,6 +126,8 @@ class HashManager: ObservableObject {
     
     /// Number of concurrent server checks
     private let checkConcurrency = 5
+    /// Number of concurrent asset hashes
+    private static let hashConcurrency = 3
     /// Batch size for server checks
     private let checkBatchSize = 10
     /// Batch size for iCloud ID lookups
@@ -210,7 +236,7 @@ class HashManager: ObservableObject {
                             self.processingProgress = 0
                             self.statusMessage = "Analyzing photos (0/\(remainingNeedingHash.count))..."
 
-                            self.processHashItemsSerially(runID: runID)
+                            self.processHashItems(runID: runID)
                         }
                     }
                 }
@@ -336,10 +362,10 @@ class HashManager: ObservableObject {
         }
     }
     
-    /// Processes one PhotoKit resource request at a time. PhotoKit controls chunk
-    /// delivery and may retain buffers until completion, so overlapping requests
-    /// can multiply peak memory for large photos, RAW files, and videos.
-    private func processHashItemsSerially(runID: UUID) {
+    /// Processes hashes with a small fan-out. File-based resource access keeps
+    /// only a fixed read buffer per request in-process, so bounded concurrency
+    /// pipelines iCloud downloads and hashing without memory growth.
+    private func processHashItems(runID: UUID) {
         guard isCurrentRun(runID), !shouldStop else {
             finishProcessing(runID: runID)
             return
@@ -362,8 +388,8 @@ class HashManager: ObservableObject {
                 self.processingQueue.removeAll(keepingCapacity: false)
             }
 
-            await HashPipelinePolicy.processSerially(identifiersToProcess) { identifier in
-                guard self.isCurrentRun(runID), !self.shouldStop else { return }
+            await HashPipelinePolicy.processConcurrently(identifiersToProcess, limit: Self.hashConcurrency) { [weak self] identifier in
+                guard let self, self.isCurrentRun(runID), !self.shouldStop else { return }
 
                 await MainActor.run {
                     guard self.isCurrentRun(runID) else { return }

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -2,10 +2,130 @@ import Foundation
 import Photos
 import Combine
 
+/// FIFO admission to a shared resource budget (bytes or slots) with
+/// cancellation-safe async acquisition. Acquisition returns false when the
+/// waiting task is cancelled before admission, so callers never release a
+/// reservation they do not hold. An amount larger than the whole limit is
+/// admitted alone while idle, so oversized items cannot starve.
+final class ResourceBudget: @unchecked Sendable {
+    private final class Waiter: @unchecked Sendable {
+        let amount: Int64
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<Bool, Never>?
+        private var isAdmitted = false
+
+        init(amount: Int64) { self.amount = amount }
+
+        /// Returns true when already admitted and the caller must resume itself.
+        func install(_ continuation: CheckedContinuation<Bool, Never>) -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if isAdmitted { return true }
+            self.continuation = continuation
+            return false
+        }
+
+        /// Returns the continuation to resume with success, if not cancelled.
+        func admit() -> CheckedContinuation<Bool, Never>? {
+            lock.lock()
+            defer { lock.unlock() }
+            guard !isCancelledFlag else { return nil }
+            isAdmitted = true
+            let continuation = self.continuation
+            self.continuation = nil
+            return continuation
+        }
+
+        private var isCancelledFlag = false
+
+        /// Marks cancellation; resumes with false unless already admitted.
+        /// Returns false when admission already happened.
+        func cancelWaiting() -> Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            if isAdmitted { return false }
+            isCancelledFlag = true
+            let continuation = self.continuation
+            self.continuation = nil
+            continuation?.resume(returning: false)
+            return true
+        }
+    }
+
+    private let lock = NSLock()
+    private let limit: Int64
+    private var available: Int64
+    private var waiters: [Waiter] = []
+
+    init(limit: Int64) {
+        self.limit = limit
+        self.available = limit
+    }
+
+    /// true = reserved (caller MUST release); false = cancelled before admission.
+    func acquire(_ amount: Int64) async -> Bool {
+        let waiter = Waiter(amount: amount)
+        lock.lock()
+        if waiters.isEmpty, amount <= available || available == limit {
+            available -= amount
+            lock.unlock()
+            return true
+        }
+        waiters.append(waiter)
+        drainLocked()
+        lock.unlock()
+
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                if waiter.install(continuation) {
+                    continuation.resume(returning: true)
+                }
+            }
+        } onCancel: {
+            lock.lock()
+            if let index = waiters.firstIndex(where: { $0 === waiter }) {
+                waiters.remove(at: index)
+            }
+            _ = waiter.cancelWaiting()
+            drainLocked()
+            lock.unlock()
+        }
+    }
+
+    func release(_ amount: Int64) {
+        lock.lock()
+        available += amount
+        drainLocked()
+        lock.unlock()
+    }
+
+    /// Reconciles a held reservation with the actual amount consumed. Never
+    /// blocks: temp files are already on disk, so overdrawn availability just
+    /// delays the next admission until the extra is released.
+    func adjust(from old: Int64, to new: Int64) {
+        lock.lock()
+        available += old - new
+        drainLocked()
+        lock.unlock()
+    }
+
+    /// Caller holds the lock. Admits the queue head only (strict FIFO).
+    private func drainLocked() {
+        while let first = waiters.first {
+            if first.amount <= available || (available == limit && waiters.count == 1) {
+                waiters.removeFirst()
+                available -= first.amount
+                first.admit()?.resume(returning: true)
+            } else {
+                break
+            }
+        }
+    }
+}
+
 enum HashPipelinePolicy {
-    /// Runs operations with at most `limit` in flight. PhotoKit file requests
-    /// keep only a fixed read buffer in-process, so a small fan-out pipelines
-    /// iCloud downloads and hashing without meaningful memory growth.
+    /// Runs operations with at most `limit` in flight (FIFO order, bounded
+    /// window: one completion admits the next element).
     static func processConcurrently<Element: Sendable>(
         _ elements: [Element],
         limit: Int,
@@ -126,7 +246,15 @@ class HashManager: ObservableObject {
     
     /// Number of concurrent server checks
     private let checkConcurrency = 5
-    /// Number of concurrent asset hashes
+    /// Assets downloading to temp files at once. Larger than the hash gate so
+    /// iCloud downloads always run ahead of hashing.
+    private static let downloadWindow = 6
+    /// Total bytes allowed in temp files at once. Bounds on-disk footprint
+    /// independently of how many downloads are in flight; a resource larger
+    /// than the whole budget is admitted alone (see ResourceBudget).
+    private static let diskBudgetBytes: Int64 = 1_500 * 1024 * 1024
+    /// Assets hashed concurrently. Hashing reads with a fixed buffer, so this
+    /// only caps CPU/IO overlap, not memory.
     private static let hashConcurrency = 3
     /// Batch size for server checks
     private let checkBatchSize = 10
@@ -362,9 +490,11 @@ class HashManager: ObservableObject {
         }
     }
     
-    /// Processes hashes with a small fan-out. File-based resource access keeps
-    /// only a fixed read buffer per request in-process, so bounded concurrency
-    /// pipelines iCloud downloads and hashing without memory growth.
+    /// Producer-consumer hashing: a download window streams originals to temp
+    /// files (admitted by a shared byte budget so the on-disk footprint stays
+    /// bounded), while a smaller hash gate consumes finished files and deletes
+    /// them right after hashing. Downloads pipeline ahead of hashing instead of
+    /// being serialized behind it.
     private func processHashItems(runID: UUID) {
         guard isCurrentRun(runID), !shouldStop else {
             finishProcessing(runID: runID)
@@ -388,24 +518,41 @@ class HashManager: ObservableObject {
                 self.processingQueue.removeAll(keepingCapacity: false)
             }
 
-            await HashPipelinePolicy.processConcurrently(identifiersToProcess, limit: Self.hashConcurrency) { [weak self] identifier in
-                guard let self, self.isCurrentRun(runID), !self.shouldStop else { return }
-
-                await MainActor.run {
-                    guard self.isCurrentRun(runID) else { return }
-                    self.syncStatusCache[identifier] = .processing
-                    self.objectWillChange.send()
-                }
-
-                await self.processHashForAsset(identifier: identifier, runID: runID)
-
-                await MainActor.run {
-                    guard self.isCurrentRun(runID) else { return }
-                    self.processedAssetsCount += 1
-                    self.processingProgress = Double(self.processedAssetsCount) / Double(self.totalAssetsToProcess)
-                    self.statusMessage = "Analyzing photos (\(self.processedAssetsCount)/\(self.totalAssetsToProcess))..."
-                }
+            let budget = ResourceBudget(limit: Self.diskBudgetBytes)
+            let hashGate = ResourceBudget(limit: Int64(Self.hashConcurrency))
+            let registry = PreparedWorkRegistry()
+            var streamContinuation: AsyncStream<PreparedHashWork>.Continuation!
+            // Unbounded is safe: the producer window plus the byte budget cap
+            // how many prepared works can ever be queued; a dropping policy
+            // would lose handoffs and leak budget reservations.
+            let pending = AsyncStream<PreparedHashWork>(bufferingPolicy: .unbounded) { continuation in
+                streamContinuation = continuation
             }
+
+            // Producer and consumer are both children of hashTask so cancelling
+            // the run propagates to in-flight downloads, not just hashing.
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { [weak self] in
+                    guard let self else {
+                        streamContinuation.finish()
+                        return
+                    }
+                    await self.downloadHashItems(
+                        identifiers: identifiersToProcess,
+                        budget: budget,
+                        registry: registry,
+                        runID: runID,
+                        continuation: streamContinuation
+                    )
+                }
+                group.addTask { [weak self] in
+                    await self?.consumeHashStream(pending, gate: hashGate, runID: runID)
+                }
+                await group.waitForAll()
+            }
+            // A cancelled iterator discards buffered elements; guarantee their
+            // temp files and reservations are released.
+            registry.sweep()
 
             await MainActor.run {
                 if self.isCurrentRun(runID), !self.shouldStop, !Task.isCancelled {
@@ -417,55 +564,181 @@ class HashManager: ObservableObject {
             }
         }
     }
-    
-    private func processHashForAsset(identifier: String, runID: UUID) async {
-        let hashStartedAt = Date()
-        logInfo("Hash started: asset=\(identifier)", category: .hash)
+
+    /// Downloads planned resources within the budget and publishes prepared
+    /// temp files to `continuation`; also owns per-asset status UI.
+    private func downloadHashItems(
+        identifiers: [String],
+        budget: ResourceBudget,
+        registry: PreparedWorkRegistry,
+        runID: UUID,
+        continuation: AsyncStream<PreparedHashWork>.Continuation
+    ) async {
+        await withTaskGroup(of: Void.self) { group in
+            let limit = Self.downloadWindow
+            var index = 0
+            var inFlight = 0
+
+            func addNext() {
+                guard index < identifiers.count, inFlight < limit else { return }
+                let identifier = identifiers[index]
+                index += 1
+                inFlight += 1
+                group.addTask { [weak self] in
+                    guard let self else { return }
+                    await self.downloadHashItem(
+                        identifier: identifier,
+                        budget: budget,
+                        registry: registry,
+                        runID: runID,
+                        continuation: continuation
+                    )
+                }
+            }
+
+            while inFlight < limit, index < identifiers.count { addNext() }
+
+            while inFlight > 0 {
+                _ = await group.next()
+                inFlight -= 1
+                addNext()
+            }
+        }
+        continuation.finish()
+    }
+
+    private func downloadHashItem(
+        identifier: String,
+        budget: ResourceBudget,
+        registry: PreparedWorkRegistry,
+        runID: UUID,
+        continuation: AsyncStream<PreparedHashWork>.Continuation
+    ) async {
+        guard isCurrentRun(runID), !shouldStop, !Task.isCancelled else { return }
+
+        await MainActor.run {
+            guard self.isCurrentRun(runID) else { return }
+            self.syncStatusCache[identifier] = .processing
+            self.objectWillChange.send()
+        }
+
         let fetchResult = PHAsset.fetchAssets(withLocalIdentifiers: [identifier], options: nil)
-        guard isCurrentRun(runID), !shouldStop else { return }
-        
-        guard let asset = fetchResult.firstObject else {
+        guard isCurrentRun(runID), !shouldStop, !Task.isCancelled else { return }
+
+        guard let asset = fetchResult.firstObject,
+              let resources = AssetResourceSelector.select(for: asset) else {
             await MainActor.run {
                 guard self.isCurrentRun(runID) else { return }
                 self.syncStatusCache[identifier] = .error
+                self.processedAssetsCount += 1
                 self.objectWillChange.send()
             }
             return
         }
-        
+
+        // Reserve on the size estimate (may be 0 for iCloud-optimised assets;
+        // floor of 1 keeps the FIFO honest). Corrected to the actual on-disk
+        // size once delivered.
+        let estimate = max(resources.plan.estimatedBytes, 1)
+        guard await budget.acquire(estimate) else { return }
+
+        let files: AssetTempFiles
         do {
-            // Use multi-resource hash to capture both JPEG and RAW hashes
-            let result = try await HashService.shared.calculateMultiResourceHash(for: asset)
+            files = try await HashService.shared.prepare(resources)
+        } catch {
+            budget.release(estimate)
+            if !Task.isCancelled {
+                logError("Resource download failed: asset=\(identifier), error=\(error.localizedDescription)", category: .hash)
+                await MainActor.run {
+                    guard self.isCurrentRun(runID) else { return }
+                    self.syncStatusCache[identifier] = .error
+                    self.processedAssetsCount += 1
+                    self.objectWillChange.send()
+                }
+            }
+            return
+        }
+
+        let actual = files.actualBytes
+        budget.adjust(from: estimate, to: actual)
+
+        // Hand the files to the consumer; the registry entry lets the run sweep
+        // them if the cancelled stream discards the buffered handoff. The
+        // reservation stays charged until the consumer completes the work.
+        let work = PreparedHashWork(files: files, reservedBytes: actual, budget: budget)
+        registry.record(work)
+        continuation.yield(work)
+    }
+
+    /// Consumer: keeps `hashConcurrency` assets hashing at a time; each item's
+    /// disk reservation is released after its files are deleted.
+    private func consumeHashStream(
+        _ stream: AsyncStream<PreparedHashWork>,
+        gate: ResourceBudget,
+        runID: UUID
+    ) async {
+        await withTaskGroup(of: Void.self) { group in
+            for await work in stream {
+                guard await gate.acquire(1) else {
+                    work.complete()
+                    for await orphan in stream { orphan.complete() }
+                    break
+                }
+                group.addTask { [weak self] in
+                    guard let self else { work.complete(); return }
+                    await self.hashPreparedAsset(work, runID: runID)
+                    await gate.release(1)
+                }
+            }
+            await group.waitForAll()
+        }
+    }
+
+    /// Hashes one prepared asset, records status/progress, and releases its
+    /// disk reservation once the temp files are gone.
+    private func hashPreparedAsset(_ work: PreparedHashWork, runID: UUID) async {
+        let files = work.files
+        defer { work.complete() }
+        let identifier = files.plan.localIdentifier
+        let hashStartedAt = Date()
+
+        do {
+            let result = try await HashService.shared.hash(files)
             guard isCurrentRun(runID), !shouldStop else { return }
             logInfo(
                 "Hash finished: asset=\(identifier), primaryBytes=\(result.primaryFileSize), rawBytes=\(result.rawFileSize ?? 0), hasRAW=\(result.hasRAW), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(hashStartedAt)))s",
                 category: .hash
             )
-            
+
             DatabaseManager.shared.saveMultiResourceHashCache(
                 localIdentifier: result.localIdentifier,
                 primaryHash: result.primaryHash,
                 rawHash: result.rawHash,
                 hasRAW: result.hasRAW,
-                modificationDate: asset.modificationDate
+                modificationDate: files.plan.modificationDate
             )
             guard isCurrentRun(runID) else { return }
-            
+
             await MainActor.run {
                 guard self.isCurrentRun(runID) else { return }
+                self.processedAssetsCount += 1
+                self.processingProgress = Double(self.processedAssetsCount) / Double(self.totalAssetsToProcess)
+                self.statusMessage = "Analyzing photos (\(self.processedAssetsCount)/\(self.totalAssetsToProcess))..."
                 self.syncStatusCache[identifier] = .pending
                 self.objectWillChange.send()
             }
-            
         } catch {
+            guard !Task.isCancelled else { return }
             logError("Hash failed: asset=\(identifier), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(hashStartedAt)))s, error=\(error.localizedDescription)", category: .hash)
             await MainActor.run {
                 guard self.isCurrentRun(runID) else { return }
+                self.processedAssetsCount += 1
                 self.syncStatusCache[identifier] = .error
                 self.objectWillChange.send()
             }
         }
     }
+
     
     private func startServerCheck(runID: UUID) {
         guard isCurrentRun(runID), !shouldStop else {

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -653,18 +653,16 @@ class HashManager: ObservableObject {
             return
         }
 
-        // Unknown PhotoKit sizes reserve the whole budget so concurrent
-        // downloads cannot bypass the disk cap before actual sizes are known.
-        let estimate = resources.plan.estimatedBytes > 0
-            ? resources.plan.estimatedBytes
-            : Self.diskBudgetBytes
-        guard await budget.acquire(estimate) else { return }
+        // PhotoKit's KVC fileSize is only an estimate. Since writeData offers
+        // no byte-progress callback, reserve the full budget until delivery.
+        let reservation = Self.diskBudgetBytes
+        guard await budget.acquire(reservation) else { return }
 
         let files: AssetTempFiles
         do {
             files = try await HashService.shared.prepare(resources)
         } catch {
-            budget.release(estimate)
+            budget.release(reservation)
             if !Task.isCancelled {
                 logError("Resource download failed: asset=\(identifier), error=\(error.localizedDescription)", category: .hash)
                 await MainActor.run {
@@ -678,8 +676,8 @@ class HashManager: ObservableObject {
         }
 
         let actual = files.actualBytes
-        let charged = max(estimate, actual)
-        budget.adjust(from: estimate, to: charged)
+        let charged = max(reservation, actual)
+        budget.adjust(from: reservation, to: charged)
 
         // Hand the files to the consumer; the registry entry lets the run sweep
         // them if the cancelled stream discards the buffered handoff. The
@@ -708,9 +706,12 @@ class HashManager: ObservableObject {
                     break
                 }
                 group.addTask { [weak self] in
-                    guard let self else { work.complete(); return }
+                    defer { gate.release(1) }
+                    guard let self else {
+                        work.complete()
+                        return
+                    }
                     await self.hashPreparedAsset(work, runID: runID)
-                    await gate.release(1)
                 }
             }
             await group.waitForAll()
@@ -1017,9 +1018,7 @@ class HashManager: ObservableObject {
         isStopping = false
         runState.finishStopping()
         statusMessage = ""
-        Task { @MainActor [weak self] in
-            await self?.refreshStatusCacheAsync()
-        }
+        loadCachedStatus()
     }
 
     private func isCurrentRun(_ runID: UUID) -> Bool {

--- a/YAIIU/YAIIU/Services/HashManager.swift
+++ b/YAIIU/YAIIU/Services/HashManager.swift
@@ -19,9 +19,17 @@ final class ResourceBudget: @unchecked Sendable {
         /// Returns true when already admitted and the caller must resume itself.
         func install(_ continuation: CheckedContinuation<Bool, Never>) -> Bool {
             lock.lock()
-            defer { lock.unlock() }
-            if isAdmitted { return true }
+            if isAdmitted {
+                lock.unlock()
+                return true
+            }
+            if isCancelledFlag {
+                lock.unlock()
+                continuation.resume(returning: false)
+                return false
+            }
             self.continuation = continuation
+            lock.unlock()
             return false
         }
 
@@ -112,7 +120,7 @@ final class ResourceBudget: @unchecked Sendable {
     /// Caller holds the lock. Admits the queue head only (strict FIFO).
     private func drainLocked() {
         while let first = waiters.first {
-            if first.amount <= available || (available == limit && waiters.count == 1) {
+            if first.amount <= available || available == limit {
                 waiters.removeFirst()
                 available -= first.amount
                 first.admit()?.resume(returning: true)
@@ -152,6 +160,10 @@ enum HashPipelinePolicy {
             while inFlight > 0 {
                 _ = await group.next()
                 inFlight -= 1
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    continue
+                }
                 addNext()
             }
         }
@@ -601,6 +613,10 @@ class HashManager: ObservableObject {
             while inFlight > 0 {
                 _ = await group.next()
                 inFlight -= 1
+                guard !Task.isCancelled else {
+                    group.cancelAll()
+                    continue
+                }
                 addNext()
             }
         }
@@ -636,10 +652,11 @@ class HashManager: ObservableObject {
             return
         }
 
-        // Reserve on the size estimate (may be 0 for iCloud-optimised assets;
-        // floor of 1 keeps the FIFO honest). Corrected to the actual on-disk
-        // size once delivered.
-        let estimate = max(resources.plan.estimatedBytes, 1)
+        // Unknown PhotoKit sizes reserve the whole budget so concurrent
+        // downloads cannot bypass the disk cap before actual sizes are known.
+        let estimate = resources.plan.estimatedBytes > 0
+            ? resources.plan.estimatedBytes
+            : Self.diskBudgetBytes
         guard await budget.acquire(estimate) else { return }
 
         let files: AssetTempFiles
@@ -667,6 +684,10 @@ class HashManager: ObservableObject {
         // reservation stays charged until the consumer completes the work.
         let work = PreparedHashWork(files: files, reservedBytes: actual, budget: budget)
         registry.record(work)
+        work.onCompletion { [weak registry, weak work] in
+            guard let work else { return }
+            registry?.remove(work)
+        }
         continuation.yield(work)
     }
 

--- a/YAIIU/YAIIU/Services/HashService.swift
+++ b/YAIIU/YAIIU/Services/HashService.swift
@@ -157,11 +157,23 @@ final class PreparedHashWork: @unchecked Sendable {
     private let budget: ResourceBudget
     private let lock = NSLock()
     private var isCompleted = false
+    private var completionHandler: (@Sendable () -> Void)?
 
     init(files: AssetTempFiles, reservedBytes: Int64, budget: ResourceBudget) {
         self.files = files
         self.reservedBytes = reservedBytes
         self.budget = budget
+    }
+
+    func onCompletion(_ handler: @escaping @Sendable () -> Void) {
+        lock.lock()
+        if isCompleted {
+            lock.unlock()
+            handler()
+            return
+        }
+        completionHandler = handler
+        lock.unlock()
     }
 
     func complete() {
@@ -171,9 +183,12 @@ final class PreparedHashWork: @unchecked Sendable {
             return
         }
         isCompleted = true
+        let handler = completionHandler
+        completionHandler = nil
         lock.unlock()
         files.removeAll()
         budget.release(reservedBytes)
+        handler?()
     }
 }
 
@@ -188,6 +203,12 @@ final class PreparedWorkRegistry: @unchecked Sendable {
     func record(_ work: PreparedHashWork) {
         lock.lock()
         works.append(work)
+        lock.unlock()
+    }
+
+    func remove(_ work: PreparedHashWork) {
+        lock.lock()
+        works.removeAll { $0 === work }
         lock.unlock()
     }
 

--- a/YAIIU/YAIIU/Services/HashService.swift
+++ b/YAIIU/YAIIU/Services/HashService.swift
@@ -11,13 +11,6 @@ enum PhotoSyncStatus: String {
     case error = "error"
 }
 
-struct HashResult {
-    let localIdentifier: String
-    let sha1Hash: String
-    let fileSize: Int64
-    let calculatedAt: Date
-}
-
 /// Result containing hashes for all resources of an asset (JPEG and RAW if present)
 struct MultiResourceHashResult {
     let localIdentifier: String
@@ -32,18 +25,18 @@ struct MultiResourceHashResult {
 class StreamingSHA1 {
     private var context = CC_SHA1_CTX()
     private(set) var totalSize: Int = 0
-    
+
     init() {
         CC_SHA1_Init(&context)
     }
-    
+
     func update(data: Data) {
         totalSize += data.count
         data.withUnsafeBytes { buffer in
             _ = CC_SHA1_Update(&context, buffer.baseAddress, CC_LONG(data.count))
         }
     }
-    
+
     func finalize() -> String {
         var digest = [UInt8](repeating: 0, count: Int(CC_SHA1_DIGEST_LENGTH))
         CC_SHA1_Final(&digest, &context)
@@ -51,61 +44,39 @@ class StreamingSHA1 {
     }
 }
 
+/// Sendable descriptor of an asset's hashing plan: which logical resources to
+/// hash and how much disk they are expected to need. Selection itself happens
+/// once in `AssetResourceSelector.select(for:)`; the descriptor then crosses
+/// task boundaries between the download and hash stages.
+struct AssetResourcePlan: Sendable {
+    let localIdentifier: String
+    /// RAW-only libraries hash the RAW as the primary, with no separate RAW slot.
+    let isRAWOnly: Bool
+    let modificationDate: Date?
+    /// KVC size estimate; may be 0 for iCloud-optimised assets (caller floors it).
+    let estimatedBytes: Int64
+}
 
-class HashService {
-    static let shared = HashService()
-    
-    private static let rawIdentifiers: Set<String> = [
-        "raw-image", "dng", "arw", "cr2", "cr3", "nef", "raf", "orf", "rw2"
-    ]
-    
-    private init() {}
-    
-    func calculateHash(for asset: PHAsset) async throws -> HashResult {
+/// Resources selected for an asset: the primary (JPEG/video) and optional RAW.
+/// `PHAssetResource` is not Sendable, so this stays on the selecting thread;
+/// only `plan` is handed between stages.
+struct AssetResources {
+    let plan: AssetResourcePlan
+    /// For RAW-only assets the RAW itself is the primary.
+    let primaryResource: PHAssetResource
+    let rawResource: PHAssetResource?
+}
+
+enum AssetResourceSelector {
+    static func select(for asset: PHAsset) -> AssetResources? {
         let resources = PHAssetResource.assetResources(for: asset)
-        
-        var primaryResource: PHAssetResource?
-        
-        for resource in resources {
-            let resourceType = resource.type
-            
-            if resourceType == .fullSizePhoto || resourceType == .fullSizeVideo {
-                primaryResource = resource
-                break
-            }
-            
-            if resourceType == .photo || resourceType == .video {
-                if primaryResource == nil {
-                    primaryResource = resource
-                }
-            }
-        }
-        
-        guard let resource = primaryResource ?? resources.first else {
-            throw HashError.noResourceFound
-        }
-        
-        let (hash, size) = try await calculateSHA1Streaming(for: resource)
-        
-        return HashResult(
-            localIdentifier: asset.localIdentifier,
-            sha1Hash: hash,
-            fileSize: Int64(size),
-            calculatedAt: Date()
-        )
-    }
-    
-    /// Calculate hashes for both primary (JPEG/HEIC) and RAW resources if present.
-    /// For JPEG+RAW assets, both hashes need to be verified against server.
-    func calculateMultiResourceHash(for asset: PHAsset) async throws -> MultiResourceHashResult {
-        let resources = PHAssetResource.assetResources(for: asset)
-        
+
         var primaryResource: PHAssetResource?
         var rawResource: PHAssetResource?
-        
+
         for resource in resources {
-            let isRAW = Self.isRAWResource(resource)
-            
+            let isRAW = HashService.isRAWResource(resource)
+
             if isRAW {
                 if rawResource == nil || resource.type == .alternatePhoto {
                     rawResource = resource
@@ -121,80 +92,191 @@ class HashService {
                 }
             }
         }
-        
+
         let isRAWOnly = primaryResource == nil
-            && resources.first(where: { !Self.isRAWResource($0) }) == nil
+            && resources.first(where: { !HashService.isRAWResource($0) }) == nil
             && rawResource != nil
 
         if isRAWOnly, let raw = rawResource {
-            let (hash, size) = try await calculateSHA1Streaming(for: raw)
-            return MultiResourceHashResult(
+            let plan = AssetResourcePlan(
                 localIdentifier: asset.localIdentifier,
-                primaryHash: hash,
-                primaryFileSize: Int64(size),
-                rawHash: nil,
-                rawFileSize: nil,
-                hasRAW: false,
-                calculatedAt: Date()
+                isRAWOnly: true,
+                modificationDate: asset.modificationDate,
+                estimatedBytes: estimatedSize(of: [raw])
             )
+            return AssetResources(plan: plan, primaryResource: raw, rawResource: nil)
         }
 
-        guard let primary = primaryResource ?? resources.first(where: { !Self.isRAWResource($0) }) else {
-            throw HashError.noResourceFound
+        guard let primary = primaryResource ?? resources.first(where: { !HashService.isRAWResource($0) }) else {
+            return nil
         }
-        
-        let (primaryHash, primarySize) = try await calculateSHA1Streaming(for: primary)
-        
-        var rawHash: String?
-        var rawSize: Int64?
-        
-        if let raw = rawResource {
-            let (hash, size) = try await calculateSHA1Streaming(for: raw)
-            rawHash = hash
-            rawSize = Int64(size)
-        }
-        
-        return MultiResourceHashResult(
+
+        let plan = AssetResourcePlan(
             localIdentifier: asset.localIdentifier,
-            primaryHash: primaryHash,
-            primaryFileSize: Int64(primarySize),
-            rawHash: rawHash,
-            rawFileSize: rawSize,
-            hasRAW: rawResource != nil,
-            calculatedAt: Date()
+            isRAWOnly: false,
+            modificationDate: asset.modificationDate,
+            estimatedBytes: estimatedSize(of: [primary] + (rawResource.map { [$0] } ?? []))
         )
+        return AssetResources(plan: plan, primaryResource: primary, rawResource: rawResource)
     }
-    
-    /// Check if the given resource is a RAW format
-    private static func isRAWResource(_ resource: PHAssetResource) -> Bool {
-        if resource.type == .alternatePhoto {
-            return true
-        }
-        
-        let uti = resource.uniformTypeIdentifier.lowercased()
-        return rawIdentifiers.contains { uti.contains($0) }
-    }
-    
-    private func calculateSHA1Streaming(for resource: PHAssetResource) async throws -> (String, Int) {
-        let fileURL = try await ResourceFileAccess.tempFile(for: resource)
-        defer { try? FileManager.default.removeItem(at: fileURL) }
 
-        return try await Task.detached(priority: .utility) {
-            try FileHasher.sha1Hex(ofFileAt: fileURL)
-        }.value
+    private static func estimatedSize(of resources: [PHAssetResource]) -> Int64 {
+        resources.reduce(0) { partial, resource in
+            partial + ((resource.value(forKey: "fileSize") as? CLong).map(Int64.init) ?? 0)
+        }
     }
 }
 
-enum HashError: LocalizedError {
-    case noResourceFound
-    case calculationFailed(reason: String)
-    
-    var errorDescription: String? {
-        switch self {
-        case .noResourceFound:
-            return "No available photo resource found"
-        case .calculationFailed(let reason):
-            return "Hash calculation failed: \(reason)"
+/// Pre-downloaded temp files for one asset's planned resources.
+struct AssetTempFiles: Sendable {
+    let plan: AssetResourcePlan
+    let primaryFileURL: URL
+
+    let rawFileURL: URL?
+
+    var actualBytes: Int64 {
+        ResourceFileAccess.size(of: primaryFileURL) + (rawFileURL.map { ResourceFileAccess.size(of: $0) } ?? 0)
+    }
+
+    func removeAll() {
+        try? FileManager.default.removeItem(at: primaryFileURL)
+        if let rawFileURL {
+            try? FileManager.default.removeItem(at: rawFileURL)
+        }
+    }
+}
+
+/// One prepared asset handed from the download stage to the hash consumer.
+/// Its `reservedBytes` stay charged to the disk budget until `complete()`
+/// deletes the temp files and releases the reservation. Completion is
+/// exactly-once: whichever path reaches it first (hash, discard, run sweep)
+/// wins; the rest are no-ops.
+final class PreparedHashWork: @unchecked Sendable {
+    let files: AssetTempFiles
+    let reservedBytes: Int64
+    private let budget: ResourceBudget
+    private let lock = NSLock()
+    private var isCompleted = false
+
+    init(files: AssetTempFiles, reservedBytes: Int64, budget: ResourceBudget) {
+        self.files = files
+        self.reservedBytes = reservedBytes
+        self.budget = budget
+    }
+
+    func complete() {
+        lock.lock()
+        if isCompleted {
+            lock.unlock()
+            return
+        }
+        isCompleted = true
+        lock.unlock()
+        files.removeAll()
+        budget.release(reservedBytes)
+    }
+}
+
+/// Tracks works handed to the stream. A cancelled `AsyncStream` iterator with
+/// an unbounded policy terminates immediately and discards buffered elements,
+/// so the run sweeps this registry when it ends to guarantee every temp file
+/// is deleted and every reservation released. `complete()` is exactly-once.
+final class PreparedWorkRegistry: @unchecked Sendable {
+    private let lock = NSLock()
+    private var works: [PreparedHashWork] = []
+
+    func record(_ work: PreparedHashWork) {
+        lock.lock()
+        works.append(work)
+        lock.unlock()
+    }
+
+    func sweep() {
+        lock.lock()
+        let pending = works
+        works = []
+        lock.unlock()
+        for work in pending {
+            work.complete()
+        }
+    }
+}
+
+
+class HashService {
+    static let shared = HashService()
+
+    private static let rawIdentifiers: Set<String> = [
+        "raw-image", "dng", "arw", "cr2", "cr3", "nef", "raf", "orf", "rw2"
+    ]
+
+    private init() {}
+
+    static func isRAWResource(_ resource: PHAssetResource) -> Bool {
+        if resource.type == .alternatePhoto {
+            return true
+        }
+
+        let uti = resource.uniformTypeIdentifier.lowercased()
+        return rawIdentifiers.contains { uti.contains($0) }
+    }
+
+    /// Downloads both planned resources to temp files (bounded by the caller's
+    /// byte budget). The caller owns the files and must delete them.
+    func prepare(_ resources: AssetResources) async throws -> AssetTempFiles {
+        let primaryFileURL = try await ResourceFileAccess.tempFile(for: resources.primaryResource)
+        do {
+            let rawFileURL: URL?
+            if let rawResource = resources.rawResource {
+                rawFileURL = try await ResourceFileAccess.tempFile(for: rawResource)
+            } else {
+                rawFileURL = nil
+            }
+            return AssetTempFiles(plan: resources.plan, primaryFileURL: primaryFileURL, rawFileURL: rawFileURL)
+        } catch {
+            try? FileManager.default.removeItem(at: primaryFileURL)
+            throw error
+        }
+    }
+
+    /// Hashes prepared temp files with a bounded read buffer and deletes them.
+    /// File reads run off the cooperative pool so large originals never block it.
+    func hash(_ files: AssetTempFiles) async throws -> MultiResourceHashResult {
+        defer { files.removeAll() }
+
+        let plan = files.plan
+        let (primaryHash, primarySize) = try await Self.readFileHash(files.primaryFileURL)
+
+        var rawHash: String?
+        var rawSize: Int64?
+
+        if !plan.isRAWOnly, let rawFileURL = files.rawFileURL {
+            let (hash, size) = try await Self.readFileHash(rawFileURL)
+            rawHash = hash
+            rawSize = Int64(size)
+        }
+
+        return MultiResourceHashResult(
+            localIdentifier: plan.localIdentifier,
+            primaryHash: primaryHash,
+            primaryFileSize: Int64(primarySize),
+            rawHash: plan.isRAWOnly ? nil : rawHash,
+            rawFileSize: plan.isRAWOnly ? nil : rawSize,
+            hasRAW: !plan.isRAWOnly && files.rawFileURL != nil,
+            calculatedAt: Date()
+        )
+    }
+
+    /// File hashing on a utility-priority thread, with cancellation forwarded
+    /// so a stopped run abandons large files between chunks.
+    private static func readFileHash(_ url: URL) async throws -> (hash: String, size: Int) {
+        let task = Task.detached(priority: .utility) {
+            try FileHasher.sha1Hex(ofFileAt: url)
+        }
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
         }
     }
 }

--- a/YAIIU/YAIIU/Services/HashService.swift
+++ b/YAIIU/YAIIU/Services/HashService.swift
@@ -51,91 +51,6 @@ class StreamingSHA1 {
     }
 }
 
-private final class CancellableRequestState<RequestID, Value>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var continuation: CheckedContinuation<Value, Error>?
-    private var requestID: RequestID?
-    private var cancelRequest: ((RequestID) -> Void)?
-    private var isCancelled = false
-    private var isCompleted = false
-
-    func installContinuation(_ continuation: CheckedContinuation<Value, Error>) {
-        lock.lock()
-        self.continuation = continuation
-        lock.unlock()
-    }
-
-    func installRequest(_ requestID: RequestID, cancel: @escaping (RequestID) -> Void) {
-        lock.lock()
-        guard !isCompleted else {
-            lock.unlock()
-            return
-        }
-        self.requestID = requestID
-        cancelRequest = cancel
-        let shouldCancel = isCancelled
-        lock.unlock()
-
-        if shouldCancel {
-            cancel(requestID)
-        }
-    }
-
-    func cancel() {
-        lock.lock()
-        guard !isCompleted, !isCancelled else {
-            lock.unlock()
-            return
-        }
-        isCancelled = true
-        let requestID = self.requestID
-        let cancelRequest = self.cancelRequest
-        lock.unlock()
-
-        if let requestID, let cancelRequest {
-            cancelRequest(requestID)
-        }
-    }
-
-    func complete(_ result: Result<Value, Error>) {
-        lock.lock()
-        guard !isCompleted, let continuation else {
-            lock.unlock()
-            return
-        }
-        isCompleted = true
-        self.continuation = nil
-        requestID = nil
-        cancelRequest = nil
-        let isCancelled = self.isCancelled
-        lock.unlock()
-
-        if isCancelled {
-            continuation.resume(throwing: CancellationError())
-        } else {
-            continuation.resume(with: result)
-        }
-    }
-}
-
-func withCancellableRequest<RequestID, Value>(
-    start: (@escaping (Result<Value, Error>) -> Void) -> RequestID,
-    cancel: @escaping (RequestID) -> Void
-) async throws -> Value {
-    let state = CancellableRequestState<RequestID, Value>()
-
-    return try await withTaskCancellationHandler {
-        try await withCheckedThrowingContinuation { continuation in
-            state.installContinuation(continuation)
-            let requestID = start { result in
-                state.complete(result)
-            }
-            state.installRequest(requestID, cancel: cancel)
-        }
-    } onCancel: {
-        state.cancel()
-    }
-}
 
 class HashService {
     static let shared = HashService()
@@ -261,38 +176,12 @@ class HashService {
     }
     
     private func calculateSHA1Streaming(for resource: PHAssetResource) async throws -> (String, Int) {
-        let manager = PHAssetResourceManager.default()
-        let sha1 = StreamingSHA1()
-        let options = PHAssetResourceRequestOptions()
-        options.isNetworkAccessAllowed = true
-        let requestStartedAt = Date()
-        logInfo(
-            "Resource data request started: type=\(String(describing: resource.type)), networkAllowed=true",
-            category: .hash
-        )
+        let fileURL = try await ResourceFileAccess.tempFile(for: resource)
+        defer { try? FileManager.default.removeItem(at: fileURL) }
 
-        return try await withCancellableRequest { completion in
-            manager.requestData(for: resource, options: options) { chunk in
-                sha1.update(data: chunk)
-            } completionHandler: { error in
-                if let error {
-                    logError(
-                        "Resource data request failed: type=\(String(describing: resource.type)), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(requestStartedAt)))s, error=\(error.localizedDescription)",
-                        category: .hash
-                    )
-                    completion(.failure(error))
-                } else {
-                    let hash = sha1.finalize()
-                    logInfo(
-                        "Resource data request finished: type=\(String(describing: resource.type)), bytes=\(sha1.totalSize), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(requestStartedAt)))s",
-                        category: .hash
-                    )
-                    completion(.success((hash, sha1.totalSize)))
-                }
-            }
-        } cancel: { requestID in
-            manager.cancelDataRequest(requestID)
-        }
+        return try await Task.detached(priority: .utility) {
+            try FileHasher.sha1Hex(ofFileAt: fileURL)
+        }.value
     }
 }
 

--- a/YAIIU/YAIIU/Services/ImmichAPIService.swift
+++ b/YAIIU/YAIIU/Services/ImmichAPIService.swift
@@ -198,7 +198,7 @@ class ImmichAPIService: NSObject {
     ) {
         let pumpQueue = DispatchQueue(label: "com.yaiiu.upload.pump.\(filename)", qos: .userInitiated)
         pumpQueue.async {
-            outputStream.open()
+            defer { outputStream.close() }
 
             func writeAll(_ data: Data) -> Bool {
                 var offset = 0
@@ -217,46 +217,75 @@ class ImmichAPIService: NSObject {
                 return true
             }
 
-            guard writeAll(preamble) else {
-                outputStream.close()
+            guard writeAll(preamble) else { return }
+
+            // Stream the resource from a temp file rather than requestData
+            // chunks: PhotoKit retains every delivered chunk in-process, which
+            // OOM-kills long upload sessions.
+            let fileURL: URL
+            do {
+                fileURL = try self.awaitResourceFile(resource)
+            } catch {
+                logError("Resource file request failed for \(filename): \(error.localizedDescription)", category: .api)
                 return
             }
+            defer { try? FileManager.default.removeItem(at: fileURL) }
 
-            let chunkQueue = DispatchQueue(label: "com.yaiiu.upload.chunk.\(filename)")
-            let options = PHAssetResourceRequestOptions()
-            options.isNetworkAccessAllowed = true
-
-            let semaphore = DispatchSemaphore(value: 0)
-            var streamError: Error?
-
-            PHAssetResourceManager.default().requestData(
-                for: resource,
-                options: options
-            ) { chunk in
-                chunkQueue.sync {
-                    guard streamError == nil else { return }
-                    if !writeAll(chunk) {
-                        streamError = outputStream.streamError ?? ImmichAPIError.uploadFailed(reason: "Stream write failed")
-                    }
-                }
-            } completionHandler: { error in
-                if let error = error {
-                    chunkQueue.sync {
-                        streamError = error
-                    }
-                    logError("PHAssetResourceManager requestData failed for \(filename): \(error.localizedDescription)", category: .api)
-                }
-                semaphore.signal()
-            }
-
-            semaphore.wait()
-
-            if streamError == nil {
-                _ = writeAll(epilogue)
-            }
-
-            outputStream.close()
+            guard self.writeAllFile(fileURL, to: outputStream) else { return }
+            _ = writeAll(epilogue)
         }
+    }
+
+    /// Blocks the pump queue until the resource is written to a temp file.
+    /// `pumpAssetData` runs on its own serial queue, so blocking is by design;
+    /// the semaphore simply bridges the async PhotoKit completion.
+    private func awaitResourceFile(_ resource: PHAssetResource) throws -> URL {
+        let options = PHAssetResourceRequestOptions()
+        options.isNetworkAccessAllowed = true
+
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("upload-\(UUID().uuidString)")
+            .appendingPathExtension("bin")
+
+        let semaphore = DispatchSemaphore(value: 0)
+        var requestError: Error?
+        PHAssetResourceManager.default().writeData(for: resource, toFile: fileURL, options: options) { error in
+            requestError = error
+            semaphore.signal()
+        }
+        semaphore.wait()
+
+        if let requestError {
+            try? FileManager.default.removeItem(at: fileURL)
+            throw requestError
+        }
+        return fileURL
+    }
+
+    private func writeAllFile(_ fileURL: URL, to outputStream: OutputStream) -> Bool {
+        guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
+            logError("Failed to open temp resource file \(fileURL.lastPathComponent)", category: .api)
+            return false
+        }
+        defer { try? handle.close() }
+
+        while true {
+            guard let chunk = try? handle.read(upToCount: 512 * 1024), !chunk.isEmpty else { break }
+            var offset = 0
+            while offset < chunk.count {
+                let written = chunk.withUnsafeBytes { rawBuffer -> Int in
+                    guard let base = rawBuffer.baseAddress else { return -1 }
+                    let ptr = base.advanced(by: offset).assumingMemoryBound(to: UInt8.self)
+                    return outputStream.write(ptr, maxLength: chunk.count - offset)
+                }
+                if written <= 0 {
+                    logError("OutputStream write failed: \(outputStream.streamError?.localizedDescription ?? "unknown")", category: .api)
+                    return false
+                }
+                offset += written
+            }
+        }
+        return true
     }
 
     private static func buildMultipartPreamble(

--- a/YAIIU/YAIIU/Services/ImmichAPIService.swift
+++ b/YAIIU/YAIIU/Services/ImmichAPIService.swift
@@ -50,6 +50,7 @@ class ImmichAPIService: NSObject {
     private var uploadSession: URLSession!
     private var uploadDelegates: [Int: UploadTaskDelegate] = [:]
     private let delegateQueue = DispatchQueue(label: "com.yaiiu.upload.delegate", attributes: .concurrent)
+    private static let uploadFileGate = ResourceBudget(limit: 1)
     
     override private init() {
         super.init()
@@ -87,6 +88,24 @@ class ImmichAPIService: NSObject {
             throw ImmichAPIError.invalidURL
         }
 
+
+        guard await Self.uploadFileGate.acquire(1) else {
+            throw CancellationError()
+        }
+        var ownsPreparedFile = true
+        let fileURL: URL
+        do {
+            fileURL = try await ResourceFileAccess.tempFile(for: resource)
+        } catch {
+            Self.uploadFileGate.release(1)
+            throw error
+        }
+        defer {
+            if ownsPreparedFile {
+                try? FileManager.default.removeItem(at: fileURL)
+                Self.uploadFileGate.release(1)
+            }
+        }
         let boundary = UUID().uuidString
 
         let dateFormatter = ISO8601DateFormatter()
@@ -108,7 +127,7 @@ class ImmichAPIService: NSObject {
         )
         let epilogueData = "\r\n--\(boundary)--\r\n".data(using: .utf8)!
 
-        let assetFileSize: Int64 = (resource.value(forKey: "fileSize") as? CLong).map(Int64.init) ?? 0
+        let assetFileSize = ResourceFileAccess.size(of: fileURL)
         let totalContentLength = Int64(preambleData.count) + assetFileSize + Int64(epilogueData.count)
 
         let fileSizeMB = Double(assetFileSize) / 1024.0 / 1024.0
@@ -177,12 +196,19 @@ class ImmichAPIService: NSObject {
 
             task.resume()
 
+            // Transfer cleanup ownership before the asynchronous pump can
+            // finish, avoiding a double release if bytes are sent immediately.
+            ownsPreparedFile = false
             self.pumpAssetData(
-                resource: resource,
+                fileURL: fileURL,
                 preamble: preambleData,
                 epilogue: epilogueData,
                 into: outputStream,
-                filename: filename
+                filename: filename,
+                completion: {
+                    try? FileManager.default.removeItem(at: fileURL)
+                    Self.uploadFileGate.release(1)
+                }
             )
         }
 
@@ -190,16 +216,20 @@ class ImmichAPIService: NSObject {
     }
 
     private func pumpAssetData(
-        resource: PHAssetResource,
+        fileURL: URL,
         preamble: Data,
         epilogue: Data,
         into outputStream: OutputStream,
-        filename: String
+        filename: String,
+        completion: @escaping @Sendable () -> Void
     ) {
         let pumpQueue = DispatchQueue(label: "com.yaiiu.upload.pump.\(filename)", qos: .userInitiated)
         pumpQueue.async {
             outputStream.open()
-            defer { outputStream.close() }
+            defer {
+                outputStream.close()
+                completion()
+            }
 
             func writeAll(_ data: Data) -> Bool {
                 var offset = 0
@@ -219,49 +249,11 @@ class ImmichAPIService: NSObject {
             }
 
             guard writeAll(preamble) else { return }
-
-            // Stream the resource from a temp file rather than requestData
-            // chunks: PhotoKit retains every delivered chunk in-process, which
-            // OOM-kills long upload sessions.
-            let fileURL: URL
-            do {
-                fileURL = try self.awaitResourceFile(resource)
-            } catch {
-                logError("Resource file request failed for \(filename): \(error.localizedDescription)", category: .api)
-                return
-            }
-            defer { try? FileManager.default.removeItem(at: fileURL) }
-
             guard self.writeAllFile(fileURL, to: outputStream) else { return }
             _ = writeAll(epilogue)
         }
     }
 
-    /// Blocks the pump queue until the resource is written to a temp file.
-    /// `pumpAssetData` runs on its own serial queue, so blocking is by design;
-    /// the semaphore simply bridges the async PhotoKit completion.
-    private func awaitResourceFile(_ resource: PHAssetResource) throws -> URL {
-        let options = PHAssetResourceRequestOptions()
-        options.isNetworkAccessAllowed = true
-
-        let fileURL = FileManager.default.temporaryDirectory
-            .appendingPathComponent("upload-\(UUID().uuidString)")
-            .appendingPathExtension("bin")
-
-        let semaphore = DispatchSemaphore(value: 0)
-        var requestError: Error?
-        PHAssetResourceManager.default().writeData(for: resource, toFile: fileURL, options: options) { error in
-            requestError = error
-            semaphore.signal()
-        }
-        semaphore.wait()
-
-        if let requestError {
-            try? FileManager.default.removeItem(at: fileURL)
-            throw requestError
-        }
-        return fileURL
-    }
 
     private func writeAllFile(_ fileURL: URL, to outputStream: OutputStream) -> Bool {
         guard let handle = try? FileHandle(forReadingFrom: fileURL) else {
@@ -273,7 +265,9 @@ class ImmichAPIService: NSObject {
         while true {
             let chunk: Data
             do {
-                guard let data = try handle.read(upToCount: 512 * 1024), !data.isEmpty else { break }
+                guard let data = try autoreleasepool(invoking: {
+                    try handle.read(upToCount: 512 * 1024)
+                }), !data.isEmpty else { break }
                 chunk = data
             } catch {
                 logError("Failed to read temp resource \(fileURL.lastPathComponent): \(error.localizedDescription)", category: .api)

--- a/YAIIU/YAIIU/Services/ImmichAPIService.swift
+++ b/YAIIU/YAIIU/Services/ImmichAPIService.swift
@@ -271,7 +271,14 @@ class ImmichAPIService: NSObject {
         defer { try? handle.close() }
 
         while true {
-            guard let chunk = try? handle.read(upToCount: 512 * 1024), !chunk.isEmpty else { break }
+            let chunk: Data
+            do {
+                guard let data = try handle.read(upToCount: 512 * 1024), !data.isEmpty else { break }
+                chunk = data
+            } catch {
+                logError("Failed to read temp resource \(fileURL.lastPathComponent): \(error.localizedDescription)", category: .api)
+                return false
+            }
             var offset = 0
             while offset < chunk.count {
                 let written = chunk.withUnsafeBytes { rawBuffer -> Int in

--- a/YAIIU/YAIIU/Services/ImmichAPIService.swift
+++ b/YAIIU/YAIIU/Services/ImmichAPIService.swift
@@ -198,6 +198,7 @@ class ImmichAPIService: NSObject {
     ) {
         let pumpQueue = DispatchQueue(label: "com.yaiiu.upload.pump.\(filename)", qos: .userInitiated)
         pumpQueue.async {
+            outputStream.open()
             defer { outputStream.close() }
 
             func writeAll(_ data: Data) -> Bool {

--- a/YAIIU/YAIIU/Services/ResourceFileAccess.swift
+++ b/YAIIU/YAIIU/Services/ResourceFileAccess.swift
@@ -16,8 +16,8 @@ enum ResourceFileAccess {
     /// Writes the resource's original data to a fresh temp file and returns its
     /// URL. The caller owns the file and must delete it when done.
     ///
-    /// `writeData` has no public cancellation API; on task cancellation the
-    /// partial file is deleted and the eventual (ignored) completion is dropped.
+    /// `writeData` has no public cancellation API; cancellation is reported
+    /// after PhotoKit finishes so callers keep disk reservations charged.
     static func tempFile(for resource: PHAssetResource) async throws -> URL {
         let manager = PHAssetResourceManager.default()
         let options = PHAssetResourceRequestOptions()
@@ -36,7 +36,7 @@ enum ResourceFileAccess {
 
         return try await withTaskCancellationHandler {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, Error>) in
-                state.install(continuation)
+                guard state.install(continuation) else { return }
                 manager.writeData(for: resource, toFile: fileURL, options: options) { error in
                     if state.complete(error: error) {
                         let size = state.fileSize(at: fileURL)
@@ -45,9 +45,8 @@ enum ResourceFileAccess {
                             category: .hash
                         )
                     }
-                    // Abandoned (cancelled/failed) requests delete the partial file;
-                    // a cancelled write still runs to completion inside PhotoKit but
-                    // its bytes land in an unlinked file, so deletion is cooperative.
+                    // Cancellation cannot stop PhotoKit; cleanup and caller
+                    // resumption happen only after the write actually finishes.
                 }
             }
         } onCancel: {
@@ -72,18 +71,18 @@ enum ResourceFileAccess {
             self.fileURL = fileURL
         }
 
-        func install(_ continuation: CheckedContinuation<URL, Error>) {
+        func install(_ continuation: CheckedContinuation<URL, Error>) -> Bool {
             lock.lock()
             if isCancelled {
                 lock.unlock()
                 removeFile()
                 continuation.resume(throwing: CancellationError())
-                return
+                return false
             }
             self.continuation = continuation
             lock.unlock()
+            return true
         }
-
         /// Returns true if the continuation was resumed here with success.
         func complete(error: Error?) -> Bool {
             lock.lock()
@@ -110,21 +109,12 @@ enum ResourceFileAccess {
             return true
         }
 
-        /// Cancellation cannot stop the in-flight write; mark the state so the
-        /// eventual completion is dropped, and delete the partial file.
+        /// Cancellation cannot stop the in-flight write. Keep the continuation
+        /// pending until PhotoKit completes so callers retain disk accounting.
         func cancel() {
             lock.lock()
-            guard !isCancelled else {
-                lock.unlock()
-                return
-            }
             isCancelled = true
-            let continuation = self.continuation
-            self.continuation = nil
             lock.unlock()
-
-            removeFile()
-            continuation?.resume(throwing: CancellationError())
         }
 
         private func removeFile() {
@@ -149,14 +139,14 @@ enum FileHasher {
         let handle = try FileHandle(forReadingFrom: fileURL)
         defer { try? handle.close() }
 
-        while autoreleasepool(invoking: {
-            guard !Task.isCancelled else { return false }
-            guard let chunk = try? handle.read(upToCount: chunkSize), !chunk.isEmpty else {
-                return false
-            }
+        while true {
+            let chunk = try autoreleasepool(invoking: { () throws -> Data? in
+                guard !Task.isCancelled else { return nil }
+                return try handle.read(upToCount: chunkSize)
+            })
+            guard let chunk, !chunk.isEmpty else { break }
             sha1.update(data: chunk)
-            return true
-        }) {}
+        }
 
         if Task.isCancelled {
             throw CancellationError()

--- a/YAIIU/YAIIU/Services/ResourceFileAccess.swift
+++ b/YAIIU/YAIIU/Services/ResourceFileAccess.swift
@@ -1,0 +1,155 @@
+import Foundation
+import Photos
+
+/// Delivers original photo-library bytes through a temp file instead of the
+/// `requestData` chunk stream.
+///
+/// PhotoKit's `requestData` retains copies of every delivered chunk inside
+/// PhotoLibraryServicesCore and never releases them (verified via Instruments:
+/// ~10 MB pinned per hashed asset, app jetsam-killed after a few hundred
+/// photos). `writeData(for:toFile:...)` writes the same bytes straight to a
+/// caller-owned file, so peak memory stays constant at the read buffer size.
+/// The file is byte-identical to the concatenated `requestData` chunks, so
+/// checksums computed this way match existing hash-cache entries.
+enum ResourceFileAccess {
+
+    /// Writes the resource's original data to a fresh temp file and returns its
+    /// URL. The caller owns the file and must delete it when done.
+    ///
+    /// `writeData` has no public cancellation API; on task cancellation the
+    /// partial file is deleted and the eventual (ignored) completion is dropped.
+    static func tempFile(for resource: PHAssetResource) async throws -> URL {
+        let manager = PHAssetResourceManager.default()
+        let options = PHAssetResourceRequestOptions()
+        options.isNetworkAccessAllowed = true
+
+        let fileURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("resource-\(UUID().uuidString)")
+            .appendingPathExtension("bin")
+
+        let state = WriteState(fileURL: fileURL)
+        let startedAt = Date()
+        logInfo(
+            "Resource file request started: type=\(String(describing: resource.type)), networkAllowed=true",
+            category: .hash
+        )
+
+        return try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<URL, Error>) in
+                state.install(continuation)
+                manager.writeData(for: resource, toFile: fileURL, options: options) { error in
+                    if state.complete(error: error) {
+                        let size = state.fileSize(at: fileURL)
+                        logInfo(
+                            "Resource file request finished: type=\(String(describing: resource.type)), bytes=\(size), elapsed=\(String(format: "%.2f", Date().timeIntervalSince(startedAt)))s",
+                            category: .hash
+                        )
+                    }
+                    // Abandoned (cancelled/failed) requests delete the partial file;
+                    // a cancelled write still runs to completion inside PhotoKit but
+                    // its bytes land in an unlinked file, so deletion is cooperative.
+                }
+            }
+        } onCancel: {
+            state.cancel()
+        }
+    }
+
+    /// Final state of a `writeData` request: exactly one resume; file cleanup on
+    /// every terminal path (error, cancellation-after-completion).
+    private final class WriteState: @unchecked Sendable {
+        private let lock = NSLock()
+        private var continuation: CheckedContinuation<URL, Error>?
+        private var isCancelled = false
+        private let fileURL: URL
+
+        init(fileURL: URL) {
+            self.fileURL = fileURL
+        }
+
+        func install(_ continuation: CheckedContinuation<URL, Error>) {
+            lock.lock()
+            if isCancelled {
+                lock.unlock()
+                removeFile()
+                continuation.resume(throwing: CancellationError())
+                return
+            }
+            self.continuation = continuation
+            lock.unlock()
+        }
+
+        /// Returns true if the continuation was resumed here with success.
+        func complete(error: Error?) -> Bool {
+            lock.lock()
+            guard let continuation else {
+                lock.unlock()
+                removeFile()
+                return false
+            }
+            self.continuation = nil
+            let cancelled = isCancelled
+            lock.unlock()
+
+            if cancelled {
+                removeFile()
+                continuation.resume(throwing: CancellationError())
+                return false
+            }
+            if let error {
+                removeFile()
+                continuation.resume(throwing: error)
+                return false
+            }
+            continuation.resume(returning: fileURL)
+            return true
+        }
+
+        /// Cancellation cannot stop the in-flight write; mark the state so the
+        /// eventual completion is dropped, and delete the partial file.
+        func cancel() {
+            lock.lock()
+            guard !isCancelled else {
+                lock.unlock()
+                return
+            }
+            isCancelled = true
+            let continuation = self.continuation
+            self.continuation = nil
+            lock.unlock()
+
+            removeFile()
+            continuation?.resume(throwing: CancellationError())
+        }
+
+        private func removeFile() {
+            try? FileManager.default.removeItem(at: fileURL)
+        }
+
+        func fileSize(at url: URL) -> Int {
+            ((try? url.resourceValues(forKeys: [.fileSizeKey]))?.fileSize) ?? 0
+        }
+    }
+}
+
+/// Reads `fileURL` with a fixed-size buffer and returns its SHA1 hex digest.
+/// Memory is bounded by `chunkSize` regardless of file size.
+enum FileHasher {
+    static let chunkSize = 512 * 1024
+
+    static func sha1Hex(ofFileAt fileURL: URL) throws -> (hash: String, size: Int) {
+        let sha1 = StreamingSHA1()
+        let handle = try FileHandle(forReadingFrom: fileURL)
+        defer { try? handle.close() }
+
+        while autoreleasepool(invoking: {
+            guard let chunk = try? handle.read(upToCount: chunkSize), !chunk.isEmpty else {
+                return false
+            }
+            sha1.update(data: chunk)
+            return true
+        }) {}
+
+        return (sha1.finalize(), sha1.totalSize)
+    }
+}

--- a/YAIIU/YAIIU/Services/ResourceFileAccess.swift
+++ b/YAIIU/YAIIU/Services/ResourceFileAccess.swift
@@ -55,6 +55,11 @@ enum ResourceFileAccess {
         }
     }
 
+    /// Byte size of a delivered temp file; 0 if it no longer exists.
+    static func size(of fileURL: URL) -> Int64 {
+        Int64(((try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize) ?? 0)
+    }
+
     /// Final state of a `writeData` request: exactly one resume; file cleanup on
     /// every terminal path (error, cancellation-after-completion).
     private final class WriteState: @unchecked Sendable {
@@ -137,12 +142,15 @@ enum ResourceFileAccess {
 enum FileHasher {
     static let chunkSize = 512 * 1024
 
+    /// Throws `CancellationError` between chunks so a stopped run releases
+    /// large-file hashing promptly.
     static func sha1Hex(ofFileAt fileURL: URL) throws -> (hash: String, size: Int) {
         let sha1 = StreamingSHA1()
         let handle = try FileHandle(forReadingFrom: fileURL)
         defer { try? handle.close() }
 
         while autoreleasepool(invoking: {
+            guard !Task.isCancelled else { return false }
             guard let chunk = try? handle.read(upToCount: chunkSize), !chunk.isEmpty else {
                 return false
             }
@@ -150,6 +158,9 @@ enum FileHasher {
             return true
         }) {}
 
+        if Task.isCancelled {
+            throw CancellationError()
+        }
         return (sha1.finalize(), sha1.totalSize)
     }
 }

--- a/YAIIU/YAIIU/Views/PhotoDetailView.swift
+++ b/YAIIU/YAIIU/Views/PhotoDetailView.swift
@@ -1535,21 +1535,12 @@ struct PhotoDetailView: View {
                 self.fileName = resourceFilename
             }
             
-            var size: Int64 = 0
-            PHAssetResourceManager.default().requestData(
-                for: primaryResource,
-                options: nil,
-                dataReceivedHandler: { data in
-                    size += Int64(data.count)
-                },
-                completionHandler: { error in
-                    if error == nil {
-                        Task { @MainActor in
-                            self.fileSize = size
-                        }
-                    }
-                }
-            )
+            // KVC fileSize avoids materializing the original just to show a
+            // size badge; requestData streaming here retained the whole file.
+            let fileSizeValue = (primaryResource.value(forKey: "fileSize") as? CLong).map(Int64.init)
+            await MainActor.run {
+                self.fileSize = fileSizeValue
+            }
         }
         
         if let loc = location {

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -5,28 +5,48 @@ final class HashPipelinePolicyTests: XCTestCase {
     actor ConcurrencyProbe {
         private(set) var activeCount = 0
         private(set) var maximumActiveCount = 0
+        private(set) var totalCount = 0
 
         func begin() {
             activeCount += 1
+            totalCount += 1
             maximumActiveCount = max(maximumActiveCount, activeCount)
         }
 
         func end() {
             activeCount -= 1
         }
+
+        func bump() {
+            totalCount += 1
+        }
     }
 
-    func testProcessesHashOperationsSerially() async {
+    func testProcessesHashOperationsWithBoundedConcurrency() async {
         let probe = ConcurrencyProbe()
+        let limit = 3
 
-        await HashPipelinePolicy.processSerially([1, 2, 3]) { _ in
+        await HashPipelinePolicy.processConcurrently(Array(1...10), limit: limit) { _ in
             await probe.begin()
             try? await Task.sleep(nanoseconds: 10_000_000)
             await probe.end()
         }
 
         let maximumActiveCount = await probe.maximumActiveCount
-        XCTAssertEqual(maximumActiveCount, 1)
+        let total = await probe.totalCount
+        XCTAssertEqual(total, 10)
+        XCTAssertLessThanOrEqual(maximumActiveCount, limit)
+    }
+
+    func testProcessConcurrentlyRunsEveryElementOnce() async {
+        let counter = ConcurrencyProbe()
+
+        await HashPipelinePolicy.processConcurrently(Array(1...25), limit: 4) { _ in
+            await counter.bump()
+        }
+
+        let total = await counter.totalCount
+        XCTAssertEqual(total, 25)
     }
 
     func testCancellationStopsBeforeNextOperation() async {
@@ -35,7 +55,7 @@ final class HashPipelinePolicyTests: XCTestCase {
         startedSecondOperation.isInverted = true
 
         let task = Task {
-            await HashPipelinePolicy.processSerially([1, 2]) { value in
+            await HashPipelinePolicy.processConcurrently([1, 2], limit: 1) { value in
                 if value == 1 {
                     firstOperationStarted.fulfill()
                     try? await Task.sleep(nanoseconds: 1_000_000_000)

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -252,6 +252,96 @@ final class HashPipelinePolicyTests: XCTestCase {
         XCTAssertTrue(state.finish(finalRunID))
         XCTAssertFalse(state.owns(finalRunID))
     }
+
+    func testBudgetBlocksWhenExhaustedThenAdmitsOnRelease() async {
+        let budget = ResourceBudget(limit: 10)
+        let first = await budget.acquire(6)
+        XCTAssertTrue(first)
+
+        let probe = ConcurrencyProbe()
+        let second = Task {
+            if await budget.acquire(6) {
+                await probe.bump()
+            }
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let markedEarly = await probe.totalCount
+        XCTAssertEqual(markedEarly, 0, "second acquire must block while the budget is exhausted")
+
+        budget.release(6)
+        await second.value
+        let markedAfter = await probe.totalCount
+        XCTAssertEqual(markedAfter, 1)
+    }
+
+    func testOversizedRequestAdmittedAloneButNeverOverlapping() async {
+        let budget = ResourceBudget(limit: 10)
+        // Larger than the whole limit: admitted alone while idle.
+        let big = await budget.acquire(25)
+        XCTAssertTrue(big)
+
+        let probe = ConcurrencyProbe()
+        let smallFirst = Task {
+            if await budget.acquire(1) { await probe.bump() }
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let oversized = Task {
+            if await budget.acquire(20) { await probe.bump() }
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let markedEarly = await probe.totalCount
+        XCTAssertEqual(markedEarly, 0, "no admission may overlap an oversized reservation")
+
+        budget.release(25)
+        await smallFirst.value
+        // Strict FIFO: the small waiter got in; the oversized one must still
+        // wait for a fully idle budget even though headroom exists.
+        let markedPartial = await probe.totalCount
+        XCTAssertEqual(markedPartial, 1)
+
+        budget.release(1)
+        await oversized.value
+        let markedFinal = await probe.totalCount
+        XCTAssertEqual(markedFinal, 2)
+    }
+
+    func testCancelledWaiterIsNotAdmittedAndHoldsNothing() async {
+        let budget = ResourceBudget(limit: 5)
+        let held = await budget.acquire(5)
+        XCTAssertTrue(held)
+
+        let waiter = Task { await budget.acquire(4) }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        waiter.cancel()
+        let acquired = await waiter.value
+        XCTAssertFalse(acquired)
+
+        // Cancellation must not consume or corrupt the budget.
+        budget.release(5)
+        let next = await budget.acquire(5)
+        XCTAssertTrue(next)
+    }
+
+    func testAdjustReconcilesReservation() async {
+        let budget = ResourceBudget(limit: 10)
+        let held = await budget.acquire(2)
+        XCTAssertTrue(held)
+        // Actual usage larger than reserved: availability may go negative and
+        // the surplus is charged against later releases.
+        budget.adjust(from: 2, to: 9)
+        let probe = ConcurrencyProbe()
+        let waiter = Task {
+            if await budget.acquire(3) { await probe.bump() }
+        }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let markedEarly = await probe.totalCount
+        XCTAssertEqual(markedEarly, 0)
+
+        budget.release(9)
+        await waiter.value
+        let markedFinal = await probe.totalCount
+        XCTAssertEqual(markedFinal, 1)
+    }
 }
 
 private extension Collection {

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -305,6 +305,41 @@ final class HashPipelinePolicyTests: XCTestCase {
         XCTAssertEqual(markedFinal, 2)
     }
 
+    func testOversizedQueueHeadAdmitsWhenBudgetBecomesIdleWithFollowers() async {
+        let budget = ResourceBudget(limit: 10)
+        let held = await budget.acquire(10)
+        XCTAssertTrue(held)
+
+        let oversized = Task { await budget.acquire(20) }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+        let follower = Task { await budget.acquire(1) }
+        try? await Task.sleep(nanoseconds: 50_000_000)
+
+        budget.release(10)
+        let oversizedAcquired = await oversized.value
+        XCTAssertTrue(oversizedAcquired)
+
+        follower.cancel()
+        let followerAcquired = await follower.value
+        XCTAssertFalse(followerAcquired)
+        budget.release(20)
+    }
+
+    func testAlreadyCancelledBudgetAcquireReturnsFalse() async {
+        let budget = ResourceBudget(limit: 1)
+        let held = await budget.acquire(1)
+        XCTAssertTrue(held)
+
+        let waiter = Task { () -> Bool in
+            withUnsafeCurrentTask { $0?.cancel() }
+            return await budget.acquire(1)
+        }
+
+        let acquired = await waiter.value
+        XCTAssertFalse(acquired)
+        budget.release(1)
+    }
+
     func testCancelledWaiterIsNotAdmittedAndHoldsNothing() async {
         let budget = ResourceBudget(limit: 5)
         let held = await budget.acquire(5)

--- a/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
+++ b/YAIIU/YAIIUTests/HashPipelinePolicyTests.swift
@@ -232,63 +232,6 @@ final class HashPipelinePolicyTests: XCTestCase {
         XCTAssertTrue(state.finish(finalRunID))
         XCTAssertFalse(state.owns(finalRunID))
     }
-
-    func testCancellationCancelsRequestAndWaitsForCompletion() async {
-        let requestStarted = expectation(description: "request starts")
-        let cancellationForwarded = expectation(description: "cancellation reaches request")
-        let taskFinished = expectation(description: "task finishes")
-        taskFinished.isInverted = true
-        let completion = RequestCompletionBox<Int>()
-
-        let task = Task {
-            defer { taskFinished.fulfill() }
-            return try await withCancellableRequest(
-                start: { handler in
-                    completion.store(handler)
-                    requestStarted.fulfill()
-                    return 42
-                },
-                cancel: { requestID in
-                    XCTAssertEqual(requestID, 42)
-                    cancellationForwarded.fulfill()
-                }
-            )
-        }
-
-        await fulfillment(of: [requestStarted], timeout: 1.0)
-        task.cancel()
-        await fulfillment(of: [cancellationForwarded], timeout: 1.0)
-        await fulfillment(of: [taskFinished], timeout: 0.1)
-
-        completion.finish(.success(1))
-
-        do {
-            _ = try await task.value
-            XCTFail("Expected cancellation")
-        } catch is CancellationError {
-            // Expected after the underlying request reports completion.
-        } catch {
-            XCTFail("Unexpected error: \(error)")
-        }
-    }
-}
-
-private final class RequestCompletionBox<Value>: @unchecked Sendable {
-    private let lock = NSLock()
-    private var handler: ((Result<Value, Error>) -> Void)?
-
-    func store(_ handler: @escaping (Result<Value, Error>) -> Void) {
-        lock.lock()
-        self.handler = handler
-        lock.unlock()
-    }
-
-    func finish(_ result: Result<Value, Error>) {
-        lock.lock()
-        let handler = self.handler
-        lock.unlock()
-        handler?(result)
-    }
 }
 
 private extension Collection {


### PR DESCRIPTION
### **User description**
## Description

This PR fixes the OOM crash during first-time hashing and makes hashing faster by pipelining.

PhotoKit's `requestData` retains a copy of every delivered chunk inside PhotoLibraryServicesCore and never frees it (Instruments: ~10 MB pinned per hashed asset; app jetsam-killed after a few hundred photos). All hashing now goes through `writeData` to caller-owned temp files with bounded 512 KB reads, so peak memory stays constant.

On top of that, hashing is restructured as a producer-consumer pipeline: a download window of 6 streams originals to temp files ahead of a 3-slot hash gate, with a shared 1.5 GB FIFO byte budget bounding on-disk footprint (an item larger than the whole budget is admitted alone, so oversized videos never starve). Downloads and hashing now overlap instead of serializing.

- Handoff cleanup is exactly-once; a cancelled run sweeps the work registry so no temp file or budget reservation can leak
- File hashing runs detached at utility priority with cancellation forwarded
- Dead paths removed (`calculateHash`/`HashResult`, `calculateSHA1Streaming`, `withCancellableRequest`)
- Adds ResourceBudget policy tests (FIFO blocking, oversized admission, cancellation, adjust)


___

### **PR Type**
Bug fix, Enhancement, Tests


___

### **Description**
- Streams PhotoKit resources through bounded temp files

- Pipelines six downloads ahead of three hashes

- Adds FIFO byte and upload file budgets

- Covers concurrency, cancellation, and budget policies


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["PhotoKit resources"]
  B["Bounded temp files"]
  C["FIFO byte budget"]
  D["Three-slot SHA1 hashing"]
  E["Hash cache and server checks"]
  F["Upload resources"]
  G["Single-file upload gate"]
  H["Multipart streaming"]
  A -- "writeData" --> B
  B -- "six-download window" --> C
  C -- "prepared files" --> D
  D -- "cache results" --> E
  F -- "temp-file delivery" --> G
  G -- "bounded reads" --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>HashManager.swift</strong><dd><code>Pipeline downloads and hashing with bounded resources</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-48c8762133ba95f35c0c78548b2173756c771713afa5120ae70b051c752c1160">+371/-52</a></td>

</tr>

<tr>
  <td><strong>ImmichAPIService.swift</strong><dd><code>Stream uploads from temporary files safely</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-154c284418e40449c5da49bf0d1b57ced3aabe1e60406d108ddf15d0f7662dce">+71/-40</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Bug fix</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>HashService.swift</strong><dd><code>Replace PhotoKit streaming with file-based hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-5e8f0013a451135775698941b8f1f85973800786de8f7b6058c2d81c8c3cd6eb">+203/-211</a></td>

</tr>

<tr>
  <td><strong>ResourceFileAccess.swift</strong><dd><code>Add bounded temp-file delivery and SHA1 hashing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-9e75b1f234b7a2e9754bad88214e7d43dbf216d3876cbdbe0a8f1f69e1ce8bbe">+156/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>PhotoDetailView.swift</strong><dd><code>Read resource size without streaming data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-778dbb5d716479ae50f03defd796aead04c9479cb8bc047a68f9c3ce88294779">+6/-15</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>HashPipelinePolicyTests.swift</strong><dd><code>Test bounded concurrency and resource budget behavior</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-98e4b2a476d2500df42da04cb9627969a53dc3c5bff567bda9c6c391f4ef669e">+138/-50</a></td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>project.pbxproj</strong><dd><code>Register the new resource file access service</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/75/files#diff-a9ccf84fe91bc6f70ac074cf8cb838a46a4ff6cc8ee6e396d1fd9569e82e0be5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

