### PR TITLE
fix(login): detect current WiFi SSID like settings page during initial setup

### DIFF
--- a/YAIIU/YAIIU/Services/NetworkReachability.swift
+++ b/YAIIU/YAIIU/Services/NetworkReachability.swift
@@ -66,14 +66,6 @@ final class NetworkReachability: NSObject, ObservableObject {
         }
     }
     
-    func getCurrentWiFiSSID() -> String? {
-        #if targetEnvironment(simulator)
-        return nil
-        #else
-        return fetchSSIDViaCNCopy()
-        #endif
-    }
-    
     // MARK: - Private Methods
     
     private func startMonitoring() {

--- a/YAIIU/YAIIU/Views/LoginView.swift
+++ b/YAIIU/YAIIU/Views/LoginView.swift
@@ -353,7 +353,12 @@ struct LoginView: View {
                                     .foregroundColor(.secondary)
                                     .fixedSize(horizontal: false, vertical: true)
                                 Button(action: {
-                                    NetworkReachability.shared.requestLocationPermission()
+                                    // System prompt only appears for .notDetermined; denied/restricted must go through Settings
+                                    if networkReachability.locationAuthorizationStatus == .notDetermined {
+                                        networkReachability.requestLocationPermission()
+                                    } else {
+                                        openLocationSettings()
+                                    }
                                 }) {
                                     HStack(spacing: 6) {
                                         Image(systemName: "location.fill")

--- a/YAIIU/YAIIU/Views/LoginView.swift
+++ b/YAIIU/YAIIU/Views/LoginView.swift
@@ -1,3 +1,4 @@
+import CoreLocation
 import SwiftUI
 
 // MARK: - Custom Text Field Style for better UI/UX
@@ -30,6 +31,9 @@ struct LoginView: View {
     @EnvironmentObject var settingsManager: SettingsManager
     @EnvironmentObject var migrationManager: MigrationManager
 
+    // Live WiFi SSID detection shared with NetworkSettingsView
+    @ObservedObject private var networkReachability = NetworkReachability.shared
+
     @State private var serverURL: String = ""
     @State private var internalServerURL: String = ""
     @State private var wifiSSID: String = ""
@@ -39,7 +43,6 @@ struct LoginView: View {
     @State private var showError: Bool = false
     @State private var errorMessage: String = ""
     @State private var showAdvancedSettings: Bool = false
-    @State private var currentSSID: String?
 
     // Use FocusState for better keyboard management and visual feedback
     @FocusState private var focusedField: Field?
@@ -59,6 +62,24 @@ struct LoginView: View {
 
     private var trimmedInternalServerURL: String {
         internalServerURL.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    // WiFi detection mirrors the permission gating in NetworkSettingsView
+    private var needsLocationPermission: Bool {
+        let status = networkReachability.locationAuthorizationStatus
+        return status == .notDetermined || status == .denied || status == .restricted
+    }
+
+    private var needsPreciseLocation: Bool {
+        let status = networkReachability.locationAuthorizationStatus
+        let hasPermission = status == .authorizedWhenInUse || status == .authorizedAlways
+        return hasPermission && !networkReachability.isPreciseLocationEnabled
+    }
+
+    private func openLocationSettings() {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+            UIApplication.shared.open(url)
+        }
     }
 
     private var trimmedEmail: String {
@@ -308,23 +329,69 @@ struct LoginView: View {
                             }
                             .enhancedTextFieldStyle(isFocused: focusedField == .wifiSSID)
                         
-                        // Use current WiFi button
-                        if let currentSSID = currentSSID, !currentSSID.isEmpty {
+                        // Live WiFi detection (same design as NetworkSettingsView)
+                        if let detectedSSID = networkReachability.currentSSID, !detectedSSID.isEmpty {
                             Button(action: {
-                                wifiSSID = currentSSID
+                                wifiSSID = detectedSSID
                             }) {
                                 HStack(spacing: 6) {
                                     Image(systemName: "wifi")
                                         .font(.caption)
                                     Text(L10n.Settings.useCurrentWiFi)
                                         .font(.caption)
-                                    Text("(\(currentSSID))")
+                                    Text("(\(detectedSSID))")
                                         .font(.caption)
                                         .foregroundColor(.secondary)
                                 }
                             }
                             .buttonStyle(.plain)
                             .foregroundColor(.blue)
+                        } else if needsLocationPermission {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(L10n.Settings.locationPermissionHint)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Button(action: {
+                                    NetworkReachability.shared.requestLocationPermission()
+                                }) {
+                                    HStack(spacing: 6) {
+                                        Image(systemName: "location.fill")
+                                            .font(.caption)
+                                        Text(L10n.Settings.grantLocationPermission)
+                                            .font(.caption)
+                                    }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
+                            }
+                        } else if needsPreciseLocation {
+                            VStack(alignment: .leading, spacing: 8) {
+                                Text(L10n.Settings.preciseLocationHint)
+                                    .font(.caption)
+                                    .foregroundColor(.secondary)
+                                    .fixedSize(horizontal: false, vertical: true)
+                                Button(action: {
+                                    openLocationSettings()
+                                }) {
+                                    HStack(spacing: 6) {
+                                        Image(systemName: "gear")
+                                            .font(.caption)
+                                        Text(L10n.Settings.openSettings)
+                                            .font(.caption)
+                                    }
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .controlSize(.small)
+                            }
+                        } else {
+                            HStack(spacing: 6) {
+                                Image(systemName: "wifi.slash")
+                                    .font(.caption)
+                                Text(L10n.Settings.wifiNotDetected)
+                                    .font(.caption)
+                            }
+                            .foregroundColor(.secondary)
                         }
                         
                         Text(L10n.Settings.wifiSSIDHint)
@@ -338,7 +405,7 @@ struct LoginView: View {
                     removal: .opacity
                 ))
                 .onAppear {
-                    currentSSID = NetworkReachability.shared.getCurrentWiFiSSID()
+                    NetworkReachability.shared.refresh()
                 }
             }
         }


### PR DESCRIPTION
### **User description**
## Description

- Initial setup (LoginView advanced settings) now detects the current WiFi in real time via `NetworkReachability.shared.currentSSID` (`NEHotspotNetwork` async detection), replacing the old synchronous `CNCopyCurrentNetworkInfo` path — the latter always returns `nil` before location permission is granted, so on a fresh install the "Use Current WiFi" button never appeared and the SSID had to be typed manually
- Adds the same location-permission / precise-location guidance UI as the Settings page (grant-permission button, open-settings link, not-detected hint)
- Removes the now-unused `getCurrentWiFiSSID()` (the CNCopy fallback stays inside the async `fetchSSID`)


___

### **PR Type**
Bug fix


___

### **Description**
- Detect live WiFi SSID during initial setup

- Add location and precise-location guidance controls

- Open app Settings for denied permissions

- Remove obsolete synchronous SSID helper


___



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>NetworkReachability.swift</strong><dd><code>Remove obsolete synchronous SSID helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Services/NetworkReachability.swift

<ul><li>Remove obsolete synchronous <code>getCurrentWiFiSSID()</code> helper<br> <li> Preserve shared asynchronous SSID detection</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/76/files#diff-fd0507f029170bf3da725768bcfbbfdd83b3bb47f4cdb182bffd3023c4490203">+0/-8</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LoginView.swift</strong><dd><code>Add permission-aware live WiFi detection</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

YAIIU/YAIIU/Views/LoginView.swift

<ul><li>Observe shared live WiFi SSID state<br> <li> Add location and precise-location guidance<br> <li> Open app Settings for denied permissions<br> <li> Refresh network state when advanced settings appear</ul>


</details>


  </td>
  <td><a href="https://github.com/FawenYo/YAIIU/pull/76/files#diff-474d358b162712237aaceba1ecfa20e59b60097d209f4c8a0a8b9d34b4637300">+78/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

